### PR TITLE
Fix Assets Used In Storyboard Scripts Not Being Detected By Verify

### DIFF
--- a/fluXis/Database/Maps/RealmMap.cs
+++ b/fluXis/Database/Maps/RealmMap.cs
@@ -115,6 +115,9 @@ public class RealmMap : RealmObject
     public virtual MapInfo GetMapInfo() => GetMapInfo<MapInfo>();
 
     [CanBeNull]
+    public virtual string GetfullPath() => MapFiles.GetFullPath(MapSet.GetPathForFile(FileName));
+
+    [CanBeNull]
     public virtual T GetMapInfo<T>()
         where T : MapInfo, new()
     {

--- a/fluXis/Scripting/Runners/StoryboardScriptRunner.cs
+++ b/fluXis/Scripting/Runners/StoryboardScriptRunner.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using fluXis.Map;
 using fluXis.Scripting.Attributes;
 using fluXis.Scripting.Models;
@@ -59,6 +60,8 @@ public class StoryboardScriptRunner : ScriptRunner
             Logger.Add("Error when running process()!", LogLevel.Error, ex);
         }
     }
+
+    public List<StoryboardElement> GetScriptStoryboardElements() => storyboard.Elements;
 
     [LuaGlobal(Name = "Add")]
     private void add(LuaStoryboardElement element) => storyboard.Elements.Add(element.Build());

--- a/fluXis/Storyboards/Storyboard.cs
+++ b/fluXis/Storyboards/Storyboard.cs
@@ -83,25 +83,25 @@ public class Storyboard : EditorMap.IChangeNotifier
         if (cachedUsedScriptAssets.Count > 0)
             return cachedUsedScriptAssets;
 
-        var Scripts = Elements.Where(e => e.Type == StoryboardElementType.Script).ToList();
-        var luaSpriteElements = new List<StoryboardElement>();
+        var scriptElements = Elements.Where(e => e.Type == StoryboardElementType.Script).ToList();
 
-        foreach (var scriptElement in Scripts)
+        foreach (var scriptElement in scriptElements)
         {
             var directory = Path.GetDirectoryName(assetPath);
             var full = Path.Combine(directory, scriptElement.GetParameter("path", ""));
             var raw = File.ReadAllText(full);
 
             var script = new StoryboardScriptRunner(map, this);
-
             script.Run(raw);
             script?.Process(scriptElement);
 
-            luaSpriteElements = script.GetScriptStoryboardElements().Where(e => e.Type == StoryboardElementType.Sprite).ToList();
-        }
+            var luaSpriteElements = script.GetScriptStoryboardElements()
+                                        .Where(e => e.Type == StoryboardElementType.Sprite)
+                                        .ToList();
 
-        foreach (var element in luaSpriteElements)
-            cachedUsedScriptAssets.Add(element.GetParameter("file", ""));
+            foreach (var element in luaSpriteElements)
+                cachedUsedScriptAssets.Add(element.GetParameter("file", ""));
+        }
 
         return cachedUsedScriptAssets;
     }


### PR DESCRIPTION
If you were to use create elements using storyboard scripts the assets used by that script would not be registered by verify warning you of unused assets.
Since you can't upload/update mapsets with at least 1 problem detected by verify that means verify mistakes that the mapset has unused assets even though it is used by the storyboard scripts and that renders the map un-uploadable.

Also Assets in scripts aren't the only thing not being detected, the scripts themselves aren't either.