### PR TITLE
Offset Storyboard Timeline Elements' EndTime When Changing Time

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/Preset/PointSettingsTime.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/Preset/PointSettingsTime.cs
@@ -11,7 +11,7 @@ public partial class PointSettingsTime : PointSettingsTextBox
     private EditorMap map { get; }
     private ITimedObject obj { get; }
 
-    public Action<double> TimeChanged { get; set; }
+    public Action<double, double> TimeChanged { get; set; }
 
     public PointSettingsTime(EditorMap map, ITimedObject obj)
     {
@@ -25,7 +25,7 @@ public partial class PointSettingsTime : PointSettingsTextBox
         {
             if (float.TryParse(box.Text, CultureInfo.InvariantCulture, out var time))
             {
-                TimeChanged?.Invoke(time);
+                TimeChanged?.Invoke(obj.Time, time);
                 obj.Time = time;
                 map.Update(obj);
             }
@@ -37,7 +37,7 @@ public partial class PointSettingsTime : PointSettingsTextBox
     {
         Action = t =>
         {
-            TimeChanged?.Invoke(t);
+            TimeChanged?.Invoke(obj.Time, t);
             TextBox.Text = t.ToStringInvariant("0");
             obj.Time = t;
             map.Update(obj);

--- a/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/Preset/PointSettingsTime.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/Preset/PointSettingsTime.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using fluXis.Map.Structures.Bases;
 using fluXis.Utils;
@@ -9,6 +10,8 @@ public partial class PointSettingsTime : PointSettingsTextBox
 {
     private EditorMap map { get; }
     private ITimedObject obj { get; }
+
+    public Action<double> TimeChanged { get; set; }
 
     public PointSettingsTime(EditorMap map, ITimedObject obj)
     {
@@ -22,6 +25,7 @@ public partial class PointSettingsTime : PointSettingsTextBox
         {
             if (float.TryParse(box.Text, CultureInfo.InvariantCulture, out var time))
             {
+                TimeChanged?.Invoke(time);
                 obj.Time = time;
                 map.Update(obj);
             }
@@ -33,6 +37,7 @@ public partial class PointSettingsTime : PointSettingsTextBox
     {
         Action = t =>
         {
+            TimeChanged?.Invoke(t);
             TextBox.Text = t.ToStringInvariant("0");
             obj.Time = t;
             map.Update(obj);

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Globalization;
 using System.Linq;
 using fluXis.Graphics.Containers;
 using fluXis.Graphics.Sprites.Text;

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Globalization;
 using System.Linq;
 using fluXis.Graphics.Containers;
 using fluXis.Graphics.Sprites.Text;
@@ -103,7 +104,11 @@ public partial class StoryboardElementSettings : CompositeDrawable
                         Text = $"{item.Type}",
                         WebFontSize = 20
                     },
-                    new PointSettingsTime(map, item),
+                    new PointSettingsTime(map, item)
+                    {
+                        TimeChanged = newTime =>
+                            item.EndTime -= item.StartTime - newTime
+                    },
                     new PointSettingsTextBox
                     {
                         Text = "Start X",

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -105,7 +105,7 @@ public partial class StoryboardElementSettings : CompositeDrawable
                     },
                     new PointSettingsTime(map, item)
                     {
-                        TimeChanged = newTime =>
+                        TimeChanged = (oldTIme, newTime) =>
                             item.EndTime -= item.StartTime - newTime
                     },
                     new PointSettingsTextBox

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -105,8 +105,8 @@ public partial class StoryboardElementSettings : CompositeDrawable
                     },
                     new PointSettingsTime(map, item)
                     {
-                        TimeChanged = (oldTIme, newTime) =>
-                            item.EndTime -= item.StartTime - newTime
+                        TimeChanged = (oldTime, newTime) =>
+                            item.EndTime -= oldTime - newTime
                     },
                     new PointSettingsTextBox
                     {


### PR DESCRIPTION
## Old:

https://github.com/user-attachments/assets/3d191cfd-d392-4010-b575-e0ab7f9fe362

## New:

https://github.com/user-attachments/assets/dac5a5e7-f881-4663-9ae0-baac24eaf20f

