### PR TITLE
Fix Spammed Hover Animations For Status In FileSelect

### DIFF
--- a/fluXis/Graphics/UserInterface/Files/FileSelect.cs
+++ b/fluXis/Graphics/UserInterface/Files/FileSelect.cs
@@ -935,13 +935,13 @@ public partial class FileSelect : CompositeDrawable, ICloseable, IKeyBindingHand
 
         private void show(double duration)
         {
-            this.FadeIn(duration);
+            statusText.FadeIn(duration);
             pathTextBox?.FadeOut(duration);
         }
 
         private void hide(double duration)
         {
-            this.FadeOut(duration);
+            statusText.FadeOut(duration);
             pathTextBox?.FadeIn(duration);
         }
     }


### PR DESCRIPTION
before this when hovering over status text you'll see jittering between status text and the path text