### PR TITLE
Make ln head skinnable

### DIFF
--- a/fluXis/Screens/Gameplay/Ruleset/HitObjects/Long/DrawableLongNoteHead.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/HitObjects/Long/DrawableLongNoteHead.cs
@@ -16,7 +16,7 @@ public partial class DrawableLongNoteHead : DrawableLongNotePart
     [BackgroundDependencyLoader]
     private void load()
     {
-        InternalChild = Skin.GetHitObject(VisualLane, ObjectManager.KeyCount).With(d =>
+        InternalChild = Skin.GetLongNoteStart(VisualLane, ObjectManager.KeyCount).With(d =>
         {
             d.Anchor = Anchor.BottomCentre;
             d.Origin = Anchor.BottomCentre;

--- a/fluXis/Skinning/Custom/CustomSkin.cs
+++ b/fluXis/Skinning/Custom/CustomSkin.cs
@@ -208,6 +208,25 @@ public class CustomSkin : ISkin
         return null;
     }
 
+    public Drawable GetLongNoteStart(int lane, int keyCount)
+    {
+        var path = SkinJson.GetOverrideOrDefault($"HitObjects/LongNoteStart/{keyCount}k-{lane}");
+        var main = path + ".png";
+        var tintless = path + "-tintless.png";
+
+        if (!storage.Exists(main))
+            return GetHitObject(lane, keyCount);
+
+        var index = Theme.GetLaneColorIndex(lane, keyCount);
+        var drawable = new CustomHitObjectPiece(
+            SkinJson, (MapColor)index, keyCount, false,
+            textures.Get(main), textures.Get(tintless)
+        );
+
+        drawable.UpdateColor(lane, keyCount);
+        return drawable;
+    }
+
     public Drawable GetLongNoteBody(int lane, int keyCount)
     {
         var path = SkinJson.GetOverrideOrDefault($"HitObjects/LongNoteBody/{keyCount}k-{lane}");

--- a/fluXis/Skinning/Default/DefaultSkin.cs
+++ b/fluXis/Skinning/Default/DefaultSkin.cs
@@ -121,6 +121,8 @@ public class DefaultSkin : ISkin
 
     public virtual Drawable GetTickNote(int lane, int keyCount, bool small) => new DefaultTickNote(small);
 
+    public virtual Drawable GetLongNoteStart(int lane, int keyCount) => GetHitObject(lane, keyCount);
+
     public virtual Drawable GetLongNoteBody(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);

--- a/fluXis/Skinning/DefaultCircle/DefaultCircleSkin.cs
+++ b/fluXis/Skinning/DefaultCircle/DefaultCircleSkin.cs
@@ -32,6 +32,8 @@ public class DefaultCircleSkin : DefaultSkin
         return piece;
     }
 
+    public override Drawable GetLongNoteStart(int lane, int keyCount) => GetHitObject(lane, keyCount);
+
     public override Drawable GetLongNoteBody(int lane, int keyCount)
     {
         var index = Theme.GetLaneColorIndex(lane, keyCount);

--- a/fluXis/Skinning/ISkin.cs
+++ b/fluXis/Skinning/ISkin.cs
@@ -31,6 +31,7 @@ public interface ISkin : IDisposable
 
     Drawable GetHitObject(int lane, int keyCount);
     Drawable GetTickNote(int lane, int keyCount, bool small);
+    Drawable GetLongNoteStart(int lane, int keyCount);
     Drawable GetLongNoteBody(int lane, int keyCount);
     Drawable GetLongNoteEnd(int lane, int keyCount);
 

--- a/fluXis/Skinning/SkinManager.cs
+++ b/fluXis/Skinning/SkinManager.cs
@@ -493,6 +493,7 @@ public partial class SkinManager : Component, ISkin, IDragDropHandler
 
     Drawable ISkin.GetHitObject(int lane, int keyCount) => currentSkin.GetHitObject(lane, keyCount) ?? defaultSkin.GetHitObject(lane, keyCount);
     Drawable ISkin.GetTickNote(int lane, int keyCount, bool small) => currentSkin.GetTickNote(lane, keyCount, small) ?? defaultSkin.GetTickNote(lane, keyCount, small);
+    Drawable ISkin.GetLongNoteStart(int lane, int keyCount) => currentSkin.GetLongNoteStart(lane, keyCount) ?? defaultSkin.GetLongNoteStart(lane, keyCount);
     Drawable ISkin.GetLongNoteBody(int lane, int keyCount) => currentSkin.GetLongNoteBody(lane, keyCount) ?? defaultSkin.GetLongNoteBody(lane, keyCount);
     Drawable ISkin.GetLongNoteEnd(int lane, int keyCount) => currentSkin.GetLongNoteEnd(lane, keyCount) ?? defaultSkin.GetLongNoteEnd(lane, keyCount);
     VisibilityContainer ISkin.GetColumnLighting(int lane, int keyCount) => currentSkin.GetColumnLighting(lane, keyCount) ?? defaultSkin.GetColumnLighting(lane, keyCount);


### PR DESCRIPTION
Closes #182 
tested by modifying "kori's pick"

<img width="592" height="902" alt="image" src="https://github.com/user-attachments/assets/1d4f3da1-4825-4882-9917-d24e5af913f3" />
<img width="586" height="366" alt="image" src="https://github.com/user-attachments/assets/63a87bf9-4bd7-403f-93ef-8430ab42c0f6" />

as of right now it uses the path "HitObjects/LongNoteStart/{keyCount}k-{lane}" to find the image
if the file doesn't exist, it will fallback to "HitObjects/Note/{keyCount}k-{lane}"