### PR TITLE
Allow negative values in time offset

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Design/Points/Entries/Scrolling/TimeOffsetEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/Entries/Scrolling/TimeOffsetEntry.cs
@@ -97,6 +97,7 @@ public partial class TimeOffsetEntry : PointListEntry
         {
             Text = text;
             TooltipText = tooltip;
+            Min = null;
         }
     }
 }


### PR DESCRIPTION
I'm pretty sure it used to work before, but as of right now any negative values gets overwritten with a 0.

before / after

https://github.com/user-attachments/assets/0bea4df6-0b18-45ed-9c60-06fb26cd5cfb

(I didn't show it in the video, but the "start offset" textbox can also accept a negative value)

At first I wanted to add an optional parameter "allowNegative" to PointSettingsBeats' constructor, but just setting Min to null in TimeOffsetEntry's TargetOffset seemed better and required less changes