### PR TITLE
Fix Fisheye When Strength is Zero

### DIFF
--- a/fluXis.Resources/Shaders/sh_FishEye.fs
+++ b/fluXis.Resources/Shaders/sh_FishEye.fs
@@ -19,13 +19,13 @@ vec2 FishEyeUV(vec2 uv)
     float corner = length(center);
     vec2 d = uv - 0.5;
     float r = length(d);
-    
-    if (g_Strength > 0.0001)
+
+    if (g_Strength > 0.0)
     {
         float fac = g_Strength * PI * 0.5;
         uv = vec2(0.5) + normalize(d) * tan(r * fac) * corner / tan(corner * fac);
     }
-    else if (g_Strength < -0.0001)
+    else
     {
         float fac = tan(g_Strength) * PI * 2;
         uv = vec2(0.5) + normalize(d) * atan(r * -fac) * 0.5 / atan (0.5 * -fac);

--- a/fluXis.Resources/Shaders/sh_FishEye.fs
+++ b/fluXis.Resources/Shaders/sh_FishEye.fs
@@ -19,13 +19,13 @@ vec2 FishEyeUV(vec2 uv)
     float corner = length(center);
     vec2 d = uv - 0.5;
     float r = length(d);
-
-    if (g_Strength > 0.0)
+    
+    if (g_Strength > 0.0001)
     {
         float fac = g_Strength * PI * 0.5;
         uv = vec2(0.5) + normalize(d) * tan(r * fac) * corner / tan(corner * fac);
     }
-    else
+    else if (g_Strength < -0.0001)
     {
         float fac = tan(g_Strength) * PI * 2;
         uv = vec2(0.5) + normalize(d) * atan(r * -fac) * 0.5 / atan (0.5 * -fac);

--- a/fluXis/Graphics/Shaders/FishEye/FIshEyeDrawNode.cs
+++ b/fluXis/Graphics/Shaders/FishEye/FIshEyeDrawNode.cs
@@ -4,6 +4,7 @@ using osu.Framework.Graphics.Colour;
 using osu.Framework.Graphics.Primitives;
 using osu.Framework.Graphics.Rendering;
 using osu.Framework.Graphics.Shaders.Types;
+using osu.Framework.Utils;
 using osuTK.Graphics;
 
 namespace fluXis.Graphics.Shaders.FishEye;
@@ -31,7 +32,7 @@ public partial class FishEyeContainer
         {
             base.PopulateContents(renderer);
 
-            if (strength != 0)
+            if (!Precision.AlmostEquals(strength, 0))
                 drawFrameBuffer(renderer);
         }
 


### PR DESCRIPTION
Really noticeable on this map:
- https://dev.flux.moe/set/1552#2906 (Aura Overdrive! diff)

I was lazy to record this one but it's really annoying on maps.