### PR TITLE
Asynchronously Load Info Header's Drawables

### DIFF
--- a/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
+++ b/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
@@ -291,7 +291,7 @@ public partial class SelectMapInfoHeader : CompositeDrawable
         {
             RelativeSizeAxes = Axes.Both,
             LoadContent = () => new MapBackground(map) { RelativeSizeAxes = Axes.Both },
-            OnComplete = background => background.FadeInFromZero(Styling.TRANSITION_FADE)
+            OnComplete = b => b.FadeInFromZero(Styling.TRANSITION_FADE)
         };
         LoadComponent(background);
         backgrounds.Add(background);
@@ -304,7 +304,7 @@ public partial class SelectMapInfoHeader : CompositeDrawable
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre 
             },
-            OnComplete = cover => cover.FadeInFromZero(Styling.TRANSITION_FADE)
+            OnComplete = c => c.FadeInFromZero(Styling.TRANSITION_FADE)
         };
         LoadComponent(cover);
         covers.Add(cover);

--- a/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
+++ b/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
@@ -286,13 +286,22 @@ public partial class SelectMapInfoHeader : CompositeDrawable
 
         updateDifficultyValues(map, mods?.SelectedMods ?? new BindableList<IMod>());
 
-        var background = new MapBackground(map);
-        backgrounds.Add(background);
-        background.Show();
+        LoadComponentAsync(new MapBackground(map) { RelativeSizeAxes = Axes.Both }, background =>
+        {
+            background.FadeInFromZero(Styling.TRANSITION_FADE);
+            backgrounds.Add(background);
+        });
 
-        var cover = new MapCover(map.MapSet);
-        covers.Add(cover);
-        cover.Show();
+        LoadComponentAsync(new MapCover(map.MapSet)
+        {
+            RelativeSizeAxes = Axes.Both,
+            Anchor = Anchor.Centre,
+            Origin = Anchor.Centre
+        }, cover =>
+        {
+            cover.FadeInFromZero(Styling.TRANSITION_FADE);
+            covers.Add(cover);
+        });
     }
 
     private void updateDifficultyValues(RealmMap map, IList<IMod> list)


### PR DESCRIPTION
Maps with a really large resolution freezes the game briefly even though ``GlobaBackground`` and the music player asynchronously load their sprites, the header does not. 