### PR TITLE
Properly Disable ScriptWatcher When Saving

### DIFF
--- a/fluXis/Screens/Edit/Editor.cs
+++ b/fluXis/Screens/Edit/Editor.cs
@@ -576,9 +576,7 @@ public partial class Editor : FluXisScreen, IKeyBindingHandler<FluXisGlobalKeybi
         switch (e.Action)
         {
             case EditorKeybinding.Save:
-                editorMap.ScriptWatcher.Disable();
                 save();
-                editorMap.ScriptWatcher.Enable();
                 return true;
 
             case EditorKeybinding.OpenFolder:
@@ -719,6 +717,8 @@ public partial class Editor : FluXisScreen, IKeyBindingHandler<FluXisGlobalKeybi
             return true;
         }
 
+        editorMap.ScriptWatcher.Disable();
+
         var now = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         editorMap.MapInfo.TimeInEditor += now - lastSaveTime;
 
@@ -729,6 +729,8 @@ public partial class Editor : FluXisScreen, IKeyBindingHandler<FluXisGlobalKeybi
         updateStateHash();
         notifications.SendSmallText("Saved!", FontAwesome6.Solid.Check);
         lastSaveTime = now;
+        
+        editorMap.ScriptWatcher.Enable();
         return true;
     }
 


### PR DESCRIPTION
Now it's inside the save method