### PR TITLE
Dual improvements

### DIFF
--- a/fluXis.Tests/Multiplayer/TestMultiResults.cs
+++ b/fluXis.Tests/Multiplayer/TestMultiResults.cs
@@ -29,37 +29,49 @@ public partial class TestMultiResults : FluXisTestScene
         {
             new()
             {
-                Accuracy = 99f,
-                Combo = 100,
-                MaxCombo = 100,
                 Mods = new List<string>(),
-                Rank = ScoreRank.SS,
-                Score = 1000000,
-                Flawless = 100,
-                Perfect = 100,
-                Great = 0,
-                Alright = 0,
-                Okay = 0,
-                Miss = 0,
-                PlayerID = 1,
-                MapID = map.OnlineID
+                MapID = map.OnlineID,
+                Players = new List<PlayerScore>
+                {
+                    new PlayerScore
+                    {
+                        Accuracy = 99f,
+                        Combo = 100,
+                        MaxCombo = 100,
+                        Rank = ScoreRank.SS,
+                        Score = 1000000,
+                        Flawless = 100,
+                        Perfect = 100,
+                        Great = 0,
+                        Alright = 0,
+                        Okay = 0,
+                        Miss = 0,
+                        PlayerID = 1,
+                    }
+                }
             },
             new()
             {
-                Accuracy = 100f,
-                Combo = 100,
-                MaxCombo = 100,
                 Mods = new List<string>(),
-                Rank = ScoreRank.X,
-                Score = 1100000,
-                Flawless = 100,
-                Perfect = 100,
-                Great = 0,
-                Alright = 0,
-                Okay = 0,
-                Miss = 0,
-                PlayerID = 2,
-                MapID = map.OnlineID
+                MapID = map.OnlineID,
+                Players = new List<PlayerScore>
+                {
+                    new PlayerScore
+                    {
+                        Accuracy = 100f,
+                        Combo = 100,
+                        MaxCombo = 100,
+                        Rank = ScoreRank.X,
+                        Score = 1100000,
+                        Flawless = 100,
+                        Perfect = 100,
+                        Great = 0,
+                        Alright = 0,
+                        Okay = 0,
+                        Miss = 0,
+                        PlayerID = 2,
+                    }
+                }
             }
         };
 

--- a/fluXis.Tests/Screens/TestResults.cs
+++ b/fluXis.Tests/Screens/TestResults.cs
@@ -5,7 +5,6 @@ using fluXis.Map;
 using fluXis.Mods;
 using fluXis.Online.API;
 using fluXis.Online.API.Models.Scores;
-using fluXis.Online.API.Models.Users;
 using fluXis.Online.API.Requests.Scores;
 using fluXis.Online.API.Responses.Scores;
 using fluXis.Replays;
@@ -57,31 +56,38 @@ public partial class TestResults : FluXisTestScene
 
     private ScoreInfo getScore() => new()
     {
-        Accuracy = 98.661736f,
-        Rank = ScoreRank.S,
-        PerformanceRating = 8,
-        Score = 1139289,
-        MaxCombo = 1218,
-        Flawless = 898,
-        Perfect = 290,
-        Great = 30,
-        Alright = 0,
-        Okay = 0,
-        Miss = 0,
-        Mods = new List<string> { "1.5x" }
+        Mods = new List<string> { "1.5x" },
+        Players = new List<PlayerScore>
+        {
+            new PlayerScore
+            {
+                PlayerID = -1,
+                Accuracy = 98.661736f,
+                Rank = ScoreRank.S,
+                PerformanceRating = 8,
+                Score = 1139289,
+                MaxCombo = 1218,
+                Flawless = 898,
+                Perfect = 290,
+                Great = 30,
+                Alright = 0,
+                Okay = 0,
+                Miss = 0,
+            }
+        }
     };
 
     [Test]
     public void Normal()
     {
-        AddStep("Push", () => stack.Push(new Results(getMap(), getScore(), APIUser.Dummy)));
+        AddStep("Push", () => stack.Push(new Results(getMap(), getScore())));
     }
 
     [Test]
     public void WithRequestFromGameplay()
     {
         var score = getScore();
-        AddStep("Push With Request", () => stack.Push(new SoloResults(getMap(), score, APIUser.Dummy)
+        AddStep("Push With Request", () => stack.Push(new SoloResults(getMap(), score)
         {
             SubmitRequest = new SimulatedScoreRequest(score, new List<IMod>(), new Replay(), "", "", "")
         }));
@@ -90,7 +96,7 @@ public partial class TestResults : FluXisTestScene
     [Test]
     public void WithRestart()
     {
-        AddStep("Push With Restart", () => stack.Push(new Results(getMap(), getScore(), APIUser.Dummy) { OnRestart = () => Logger.Log("Restart pressed.") }));
+        AddStep("Push With Restart", () => stack.Push(new Results(getMap(), getScore()) { OnRestart = () => Logger.Log("Restart pressed.") }));
     }
 
     private class SimulatedScoreRequest : ScoreSubmitRequest

--- a/fluXis.Tests/Select/TestScoreEntry.cs
+++ b/fluXis.Tests/Select/TestScoreEntry.cs
@@ -32,18 +32,24 @@ public partial class TestScoreEntry : FluXisTestScene
                     DeleteAction = () => Logger.Log("Delete requested"),
                     ScoreInfo = new ScoreInfo
                     {
-                        Score = 1000000,
-                        MaxCombo = 100,
-                        Accuracy = 100,
                         Mods = new List<string> { "1.4x", "HD", "NF" },
-                        Rank = ScoreRank.X,
-                        Flawless = 100,
-                        Perfect = 100,
-                        Great = 100,
-                        Alright = 100,
-                        Okay = 100,
-                        Miss = 0,
                         Timestamp = DateTimeOffset.Now.ToUnixTimeSeconds(),
+                        Players = new List<PlayerScore>
+                        {
+                            new PlayerScore
+                            {
+                                Score = 1000000,
+                                MaxCombo = 100,
+                                Accuracy = 100,
+                                Rank = ScoreRank.X,
+                                Flawless = 100,
+                                Perfect = 100,
+                                Great = 100,
+                                Alright = 100,
+                                Okay = 100,
+                                Miss = 0,
+                            }
+                        }
                     }
                 }
             }

--- a/fluXis/Database/FluXisRealm.cs
+++ b/fluXis/Database/FluXisRealm.cs
@@ -11,7 +11,8 @@ using osu.Framework.Development;
 using osu.Framework.Logging;
 using osu.Framework.Platform;
 using Realms;
-using Realms.Dynamic;
+
+//using Realms.Dynamic;
 
 namespace fluXis.Database;
 
@@ -123,6 +124,8 @@ public class FluXisRealm : IDisposable
 
                 break;
 
+            //TODO: make this work again
+            /*
             case 8:
                 var newScores2 = migration.NewRealm.All<RealmScore>().ToList();
 
@@ -152,6 +155,7 @@ public class FluXisRealm : IDisposable
                 }
 
                 break;
+            */
 
             case 10:
                 var mapsets = migration.OldRealm.DynamicApi.All("RealmMapSet").ToList();
@@ -286,6 +290,8 @@ public class FluXisRealm : IDisposable
                 maps.ForEach(x => x.Settings = new RealmMapUserSettings());
                 break;
             }
+
+            //TODO: dual score migration
         }
     }
 

--- a/fluXis/Database/RealmObjectUtils.cs
+++ b/fluXis/Database/RealmObjectUtils.cs
@@ -15,7 +15,10 @@ public static class RealmObjectUtils
         c.ShouldMapField = _ => false;
         c.ShouldMapProperty = pi => pi.SetMethod?.IsPublic == true;
 
-        c.CreateMap<RealmScore, RealmScore>();
+        c.CreateMap<RealmScore, RealmScore>()
+         .ForMember(s => s.Players, cc => cc.Ignore());
+        c.CreateMap<RealmPlayerScore, RealmPlayerScore>()
+         .ForMember(s => s.RealmScore, cc => cc.Ignore());
         c.CreateMap<RealmMapMetadata, RealmMapMetadata>();
         c.CreateMap<RealmMapUserSettings, RealmMapUserSettings>();
         c.CreateMap<RealmMapFilters, RealmMapFilters>();

--- a/fluXis/Database/Score/RealmPlayerScore.cs
+++ b/fluXis/Database/Score/RealmPlayerScore.cs
@@ -1,0 +1,75 @@
+using System;
+using fluXis.Scoring;
+using fluXis.Scoring.Enums;
+using Realms;
+
+namespace fluXis.Database.Score;
+
+public class RealmPlayerScore : RealmObject
+{
+    [PrimaryKey]
+    public Guid ID { get; set; }
+
+    public RealmScore RealmScore { get; set; } = null!;
+
+    public float Accuracy { get; set; }
+    public double PerformanceRating { get; set; }
+    public string Grade { get; set; }
+    public int Score { get; set; }
+    public int MaxCombo { get; set; }
+    public int Flawless { get; set; }
+    public int Perfect { get; set; }
+    public int Great { get; set; }
+    public int Alright { get; set; }
+    public int Okay { get; set; }
+    public int Miss { get; set; }
+    public long PlayerID { get; set; }
+    public float ScrollSpeed { get; set; }
+
+    [Ignored]
+    public ScoreRank Rank
+    {
+        get => Enum.Parse<ScoreRank>(Grade);
+        set => Grade = value.ToString();
+    }
+
+    public RealmPlayerScore()
+    {
+        ID = Guid.NewGuid();
+    }
+
+    public static RealmPlayerScore FromPlayerScore(PlayerScore playerScore) => new()
+    {
+        ID = Guid.NewGuid(),
+        Accuracy = playerScore.Accuracy,
+        PerformanceRating = playerScore.PerformanceRating,
+        Rank = playerScore.Rank,
+        Score = playerScore.Score,
+        MaxCombo = playerScore.MaxCombo,
+        Flawless = playerScore.Flawless,
+        Perfect = playerScore.Perfect,
+        Great = playerScore.Great,
+        Alright = playerScore.Alright,
+        Okay = playerScore.Okay,
+        Miss = playerScore.Miss,
+        PlayerID = playerScore.PlayerID,
+        ScrollSpeed = playerScore.ScrollSpeed
+    };
+
+    public PlayerScore ToPlayerScore() => new()
+    {
+        Accuracy = Accuracy,
+        PerformanceRating = PerformanceRating,
+        Rank = Rank,
+        Score = Score,
+        MaxCombo = MaxCombo,
+        Flawless = Flawless,
+        Perfect = Perfect,
+        Great = Great,
+        Alright = Alright,
+        Okay = Okay,
+        Miss = Miss,
+        PlayerID = PlayerID,
+        ScrollSpeed = ScrollSpeed
+    };
+}

--- a/fluXis/Database/Score/RealmPlayerScore.cs
+++ b/fluXis/Database/Score/RealmPlayerScore.cs
@@ -5,11 +5,8 @@ using Realms;
 
 namespace fluXis.Database.Score;
 
-public class RealmPlayerScore : RealmObject
+public class RealmPlayerScore : EmbeddedObject
 {
-    [PrimaryKey]
-    public Guid ID { get; set; }
-
     public RealmScore RealmScore { get; set; } = null!;
 
     public float Accuracy { get; set; }
@@ -33,14 +30,8 @@ public class RealmPlayerScore : RealmObject
         set => Grade = value.ToString();
     }
 
-    public RealmPlayerScore()
-    {
-        ID = Guid.NewGuid();
-    }
-
     public static RealmPlayerScore FromPlayerScore(PlayerScore playerScore) => new()
     {
-        ID = Guid.NewGuid(),
         Accuracy = playerScore.Accuracy,
         PerformanceRating = playerScore.PerformanceRating,
         Rank = playerScore.Rank,

--- a/fluXis/FluXisGame.cs
+++ b/fluXis/FluXisGame.cs
@@ -14,7 +14,6 @@ using fluXis.Graphics.UserInterface.Panel.Types;
 using fluXis.Input;
 using fluXis.Localization;
 using fluXis.Localization.Stores;
-using fluXis.Online.API.Models.Users;
 using fluXis.Overlay.Achievements;
 using fluXis.Overlay.Auth;
 using fluXis.Overlay.Browse;
@@ -377,12 +376,12 @@ public partial class FluXisGame : FluXisGameBase, IKeyBindingHandler<FluXisGloba
 
     public override void CloseOverlays() => overlayContainer.Children.ForEach(c => c.Hide());
 
-    public override void PresentScore(RealmMap map, ScoreInfo score, APIUser player, Action replayAction = null)
+    public override void PresentScore(RealmMap map, ScoreInfo score, Action replayAction = null)
     {
         if (map == null || score == null)
             throw new ArgumentNullException();
 
-        screenStack.Push(new Results(map, score, player) { ViewReplay = replayAction });
+        screenStack.Push(new Results(map, score) { ViewReplay = replayAction });
     }
 
     public void PresentUser(long id)

--- a/fluXis/FluXisGameBase.cs
+++ b/fluXis/FluXisGameBase.cs
@@ -25,7 +25,6 @@ using fluXis.IO;
 using fluXis.Localization;
 using fluXis.Map;
 using fluXis.Online;
-using fluXis.Online.API.Models.Users;
 using fluXis.Online.Chat;
 using fluXis.Online.Collections;
 using fluXis.Online.Fluxel;
@@ -458,7 +457,7 @@ public partial class FluXisGameBase : osu.Framework.Game
 
     public virtual void CloseOverlays() { }
     public virtual void UpdateWindowTitle(string title) { }
-    public virtual void PresentScore(RealmMap map, ScoreInfo score, APIUser player, Action replayAction = null) { }
+    public virtual void PresentScore(RealmMap map, ScoreInfo score, Action replayAction = null) { }
     public virtual void ShowMap(RealmMapSet map) { }
 
     protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent) => GameDependencies = new DependencyContainer(base.CreateChildDependencies(parent));

--- a/fluXis/Import/FluXisImport.cs
+++ b/fluXis/Import/FluXisImport.cs
@@ -210,6 +210,12 @@ public class FluXisImport : MapImporter
                     keys = Math.Max(keys, hitObject.Lane);
                 }
 
+                if (mapInfo.IsSplit)
+                {
+                    if (keys % 2 == 1) keys += 1;
+                    keys /= 2;
+                }
+
                 var map = new RealmMap
                 {
                     Metadata = new RealmMapMetadata

--- a/fluXis/Import/FluXisImport.cs
+++ b/fluXis/Import/FluXisImport.cs
@@ -189,7 +189,7 @@ public class FluXisImport : MapImporter
                 var mapInfo = json.Deserialize<MapInfo>();
 
                 var length = 0f;
-                var keys = 0;
+                var keys = mapInfo.SinglePlayerKeyCount;
                 var bpmMin = float.MaxValue;
                 var bpmMax = float.MinValue;
 
@@ -207,13 +207,6 @@ public class FluXisImport : MapImporter
                         time += hitObject.HoldTime;
 
                     length = (float)Math.Max(length, time);
-                    keys = Math.Max(keys, hitObject.Lane);
-                }
-
-                if (mapInfo.IsSplit)
-                {
-                    if (keys % 2 == 1) keys += 1;
-                    keys /= 2;
                 }
 
                 var map = new RealmMap

--- a/fluXis/Map/MapInfo.cs
+++ b/fluXis/Map/MapInfo.cs
@@ -138,10 +138,20 @@ public class MapInfo
     {
         if (RealmEntry == null) return MaxComboAllPlayers; //probably shouldn't do that?
 
+        int maxCombo = 0;
+
         //the RealmEntry's KeyCount store the keycount for a single player
-        return HitObjects.Count(hitObject =>
-            hitObject.Lane >= 1 + playerIndex * RealmEntry.KeyCount &&
-            hitObject.Lane < 1 + (playerIndex + 1) * RealmEntry.KeyCount);
+        HitObjects.FindAll(hitObject =>
+                      hitObject.Lane >= 1 + playerIndex * RealmEntry.KeyCount &&
+                      hitObject.Lane < 1 + (playerIndex + 1) * RealmEntry.KeyCount)
+                  .ForEach(hitObject =>
+                  {
+                      maxCombo++;
+                      if (hitObject.LongNote)
+                          maxCombo++;
+                  });
+
+        return maxCombo;
     }
 
     public bool Validate(out string issue)

--- a/fluXis/Map/MapInfo.cs
+++ b/fluXis/Map/MapInfo.cs
@@ -73,7 +73,7 @@ public class MapInfo
     public double EndTime => HitObjects.Count == 0 ? 1000 : HitObjects[^1].EndTime;
 
     [JsonIgnore]
-    public int MaxCombo
+    public int MaxComboAllPlayers
     {
         get
         {
@@ -132,6 +132,16 @@ public class MapInfo
         TimingPoints = new List<TimingPoint> { new() { BPM = 120, Time = 0, Signature = 4 } }; // Add default timing point to avoid issues
         ScrollVelocities = new List<ScrollVelocity>();
         HitSoundFades = new List<HitSoundFade>();
+    }
+
+    public int MaxComboForPlayer(int playerIndex)
+    {
+        if (RealmEntry == null) return MaxComboAllPlayers; //probably shouldn't do that?
+
+        //the RealmEntry's KeyCount store the keycount for a single player
+        return HitObjects.Count(hitObject =>
+            hitObject.Lane >= 1 + playerIndex * RealmEntry.KeyCount &&
+            hitObject.Lane < 1 + (playerIndex + 1) * RealmEntry.KeyCount);
     }
 
     public bool Validate(out string issue)

--- a/fluXis/Online/API/Models/Multi/MultiplayerParticipant.cs
+++ b/fluXis/Online/API/Models/Multi/MultiplayerParticipant.cs
@@ -12,5 +12,7 @@ public class MultiplayerParticipant
     [JsonProperty("state")]
     public MultiplayerUserState State { get; set; }
 
+    //TODO: make it possible to select someone else in the room to play dual maps?
+
     public long ID => Player.ID;
 }

--- a/fluXis/Online/API/Models/Multi/MultiplayerRoom.cs
+++ b/fluXis/Online/API/Models/Multi/MultiplayerRoom.cs
@@ -30,5 +30,5 @@ public class MultiplayerRoom
     [JsonProperty("mods")]
     public List<string> Mods { get; set; } = new();
 
-    public List<ScoreInfo> Scores { get; set; } = new();
+    public List<ScoreInfo> Scores { get; set; } = new(); //TODO: replace this by List<PlayerScore>?
 }

--- a/fluXis/Online/API/Models/Scores/APIScore.cs
+++ b/fluXis/Online/API/Models/Scores/APIScore.cs
@@ -6,6 +6,7 @@ namespace fluXis.Online.API.Models.Scores;
 
 #nullable enable
 
+//TODO: support dual scores
 public class APIScore
 {
     [JsonProperty("id")]

--- a/fluXis/Online/API/Models/Scores/APIScoreExtraPlayer.cs
+++ b/fluXis/Online/API/Models/Scores/APIScoreExtraPlayer.cs
@@ -1,31 +1,13 @@
-using System.Collections.Generic;
-using fluXis.Online.API.Models.Maps;
 using fluXis.Online.API.Models.Users;
+using JetBrains.Annotations;
 using Newtonsoft.Json;
 
 namespace fluXis.Online.API.Models.Scores;
 
-#nullable enable
-
-public class APIScore
+public class APIScoreExtraPlayer
 {
-    [JsonProperty("id")]
-    public long ID { get; set; }
-
     [JsonProperty("user")]
     public APIUser User { get; set; } = null!;
-
-    [JsonProperty("time")]
-    public long Time { get; set; }
-
-    [JsonProperty("mode")]
-    public int Mode { get; set; }
-
-    /// <summary>
-    /// List of mods seperated by commas.
-    /// </summary>
-    [JsonProperty("mods")]
-    public string Mods { get; set; } = "";
 
     [JsonProperty("pr")]
     public double PerformanceRating { get; set; }
@@ -63,14 +45,7 @@ public class APIScore
     [JsonProperty("scrollspeed")]
     public float ScrollSpeed { get; set; }
 
-    //stores other players for dual maps
-    [JsonProperty("extra-players")]
-    public List<APIScoreExtraPlayer> ExtraPlayers { get; set; } = new();
-
-    #region Optional
-
-    [JsonProperty("map")]
-    public APIMap? Map { get; set; }
-
-    #endregion
+    [JsonIgnore]
+    [CanBeNull]
+    public APIScore Score { get; set; }
 }

--- a/fluXis/Online/API/Requests/Maps/MapLeaderboardRequest.cs
+++ b/fluXis/Online/API/Requests/Maps/MapLeaderboardRequest.cs
@@ -10,17 +10,20 @@ public class MapLeaderboardRequest : APIRequest<MapLeaderboard>
 
     private ScoreListType type { get; }
     private long id { get; }
+    private long playerIndex { get; }
 
-    public MapLeaderboardRequest(ScoreListType type, long id)
+    public MapLeaderboardRequest(ScoreListType type, long id, int playerIndex = 0)
     {
         this.type = type;
         this.id = id;
+        this.playerIndex = playerIndex;
     }
 
     protected override WebRequest CreateWebRequest(string url)
     {
         var req = base.CreateWebRequest(url);
         req.AddParameter("type", type.ToString().ToLower(), RequestParameterType.Query);
+        req.AddParameter("playerIndex", playerIndex.ToString(), RequestParameterType.Query);
         return req;
     }
 }

--- a/fluXis/Online/Multiplayer/MultiplayerClient.cs
+++ b/fluXis/Online/Multiplayer/MultiplayerClient.cs
@@ -132,7 +132,14 @@ public abstract partial class MultiplayerClient : Component, IMultiplayerClient
         Schedule(() =>
         {
             Room.Scores = new List<ScoreInfo>();
-            Room.Scores.AddRange(Room.Participants.Where(p => p.ID != Player.ID).Select(p => new ScoreInfo { PlayerID = p.ID }));
+
+            //TODO: consider dual maps
+            Room.Scores.AddRange(Room.Participants.Where(p => p.ID != Player.ID).Select(p =>
+            {
+                ScoreInfo scoreInfo = new ScoreInfo();
+                scoreInfo.Players.Add(new PlayerScore { PlayerID = p.ID });
+                return scoreInfo;
+            }));
 
             OnStart?.Invoke();
         });

--- a/fluXis/Scoring/PlayerScore.cs
+++ b/fluXis/Scoring/PlayerScore.cs
@@ -1,0 +1,76 @@
+using System.Collections.Generic;
+using fluXis.Scoring.Enums;
+using fluXis.Scoring.Structs;
+using Newtonsoft.Json;
+
+namespace fluXis.Scoring;
+
+#nullable enable
+
+public class PlayerScore
+{
+    [JsonProperty("accuracy")]
+    public float Accuracy { get; set; }
+
+    [JsonProperty("grade")]
+    public ScoreRank Rank { get; set; }
+
+    [JsonProperty("score")]
+    public int Score { get; set; }
+
+    [JsonProperty("pr")]
+    public double PerformanceRating { get; set; }
+
+    [JsonProperty("combo")]
+    public int Combo { get; set; }
+
+    [JsonProperty("maxCombo")]
+    public int MaxCombo { get; set; }
+
+    [JsonProperty("flawless")]
+    public int Flawless { get; set; }
+
+    [JsonProperty("perfect")]
+    public int Perfect { get; set; }
+
+    [JsonProperty("great")]
+    public int Great { get; set; }
+
+    [JsonProperty("alright")]
+    public int Alright { get; set; }
+
+    [JsonProperty("okay")]
+    public int Okay { get; set; }
+
+    [JsonProperty("miss")]
+    public int Miss { get; set; }
+
+    [JsonProperty("player")]
+    public long PlayerID { get; set; }
+
+    [JsonProperty("results")]
+    public List<HitResult>? HitResults { get; set; } = new();
+
+    [JsonProperty("scrollspeed")]
+    public float ScrollSpeed { get; set; }
+
+    [JsonIgnore]
+    public long Ratio
+    {
+        get
+        {
+            var nonFlawless = Perfect + Great + Alright + Okay + Miss;
+
+            if (nonFlawless == 0)
+                return 0;
+
+            return Flawless * 100 / nonFlawless;
+        }
+    }
+
+    [JsonIgnore]
+    public bool FullFlawless => Flawless == MaxCombo;
+
+    [JsonIgnore]
+    public bool FullCombo => Miss == 0;
+}

--- a/fluXis/Scoring/Processing/Health/DrainHealthProcessor.cs
+++ b/fluXis/Scoring/Processing/Health/DrainHealthProcessor.cs
@@ -21,10 +21,10 @@ public class DrainHealthProcessor : HealthProcessor
     {
     }
 
-    public override void ApplyMap(MapInfo map)
+    public override void ApplyMap(MapInfo map, int playerIndex)
     {
-        base.ApplyMap(map);
-        maxCombo = map.MaxCombo;
+        base.ApplyMap(map, playerIndex);
+        maxCombo = map.MaxComboForPlayer(playerIndex);
         endTime = map.EndTime;
         factor = 0.008f + 80f / maxCombo;
     }

--- a/fluXis/Scoring/Processing/Health/HealthProcessor.cs
+++ b/fluXis/Scoring/Processing/Health/HealthProcessor.cs
@@ -62,7 +62,7 @@ public class HealthProcessor : JudgementDependant
             Health.Value = Health.MinValue;
     }
 
-    public override void ApplyMap(MapInfo map) => Map = map;
+    public override void ApplyMap(MapInfo map, int playerIndex) => Map = map;
 
     public override void AddResult(HitResult result)
     {

--- a/fluXis/Scoring/Processing/Health/RequirementHeathProcessor.cs
+++ b/fluXis/Scoring/Processing/Health/RequirementHeathProcessor.cs
@@ -19,9 +19,9 @@ public class RequirementHeathProcessor : HealthProcessor
     {
     }
 
-    public override void ApplyMap(MapInfo map)
+    public override void ApplyMap(MapInfo map, int playerIndex)
     {
-        multiplier = 1f / (map.MaxCombo * 0.05f);
+        multiplier = 1f / (map.MaxComboForPlayer(playerIndex) * 0.05f);
         multiplier *= 100f;
     }
 

--- a/fluXis/Scoring/Processing/JudgementDependant.cs
+++ b/fluXis/Scoring/Processing/JudgementDependant.cs
@@ -6,7 +6,7 @@ namespace fluXis.Scoring.Processing;
 public abstract class JudgementDependant
 {
     public JudgementProcessor JudgementProcessor { get; set; }
-    public virtual void ApplyMap(MapInfo map) { }
+    public virtual void ApplyMap(MapInfo map, int playerIndex) { }
     public virtual void AddResult(HitResult result) { }
     public virtual void RevertResult(HitResult result) { }
 }

--- a/fluXis/Scoring/Processing/JudgementProcessor.cs
+++ b/fluXis/Scoring/Processing/JudgementProcessor.cs
@@ -22,9 +22,9 @@ public class JudgementProcessor
         }
     }
 
-    public void ApplyMap(MapInfo map)
+    public void ApplyMap(MapInfo map, int playerIndex)
     {
-        dependants.ForEach(d => d.ApplyMap(map));
+        dependants.ForEach(d => d.ApplyMap(map, playerIndex));
     }
 
     public void AddResult(HitResult result)

--- a/fluXis/Scoring/Processing/ScoreProcessor.cs
+++ b/fluXis/Scoring/Processing/ScoreProcessor.cs
@@ -18,6 +18,7 @@ public class ScoreProcessor : JudgementDependant
 
     public HitWindows HitWindows { get; init; }
     public MapInfo MapInfo { get; init; }
+    public int MapMaxCombo { get; init; }
     public List<IMod> Mods { get; init; }
 
     public BindableFloat Accuracy { get; } = new(100);
@@ -76,8 +77,8 @@ public class ScoreProcessor : JudgementDependant
         var scoreMultiplier = 1f + Mods.Sum(mod => mod.ScoreMultiplier - 1f);
 
         var maxScore = 1000000 * scoreMultiplier;
-        var accBased = (int)(ratedNotes / MapInfo.MaxCombo * (maxScore * .9f));
-        var comboBased = (int)(MaxCombo / (float)MapInfo.MaxCombo * (maxScore * .1f));
+        var accBased = (int)(ratedNotes / MapMaxCombo * (maxScore * .9f));
+        var comboBased = (int)(MaxCombo / (float)MapMaxCombo * (maxScore * .1f));
         return accBased + comboBased;
     }
 

--- a/fluXis/Scoring/Processing/ScoreProcessor.cs
+++ b/fluXis/Scoring/Processing/ScoreProcessor.cs
@@ -83,6 +83,33 @@ public class ScoreProcessor : JudgementDependant
 
     public ScoreInfo ToScoreInfo() => new()
     {
+        MapID = MapInfo.RealmEntry!.OnlineID,
+        Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+        Mods = Mods.Select(m => m.Acronym).ToList(),
+        Players = new List<PlayerScore>
+        {
+            new()
+            {
+                Accuracy = Accuracy.Value,
+                PerformanceRating = PerformanceRating.Value,
+                Rank = Rank.Value,
+                Score = Score,
+                Combo = Combo.Value,
+                MaxCombo = MaxCombo,
+                Flawless = Flawless,
+                Perfect = Perfect,
+                Great = Great,
+                Alright = Alright,
+                Okay = Okay,
+                Miss = Miss,
+                HitResults = JudgementProcessor.Results,
+                PlayerID = Player.ID,
+            }
+        }
+    };
+
+    public PlayerScore ToPlayerScoreInfo() => new()
+    {
         Accuracy = Accuracy.Value,
         PerformanceRating = PerformanceRating.Value,
         Rank = Rank.Value,
@@ -96,10 +123,7 @@ public class ScoreProcessor : JudgementDependant
         Okay = Okay,
         Miss = Miss,
         HitResults = JudgementProcessor.Results,
-        MapID = MapInfo.RealmEntry!.OnlineID,
-        PlayerID = Player.ID,
-        Timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
-        Mods = Mods.Select(m => m.Acronym).ToList()
+        PlayerID = Player.ID
     };
 
     public static double CalculatePerformance(float rating, float accuracy, int flawless, int perfect, int great, int alright, int okay, int miss, List<IMod> mods)

--- a/fluXis/Scoring/ScoreInfo.cs
+++ b/fluXis/Scoring/ScoreInfo.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using fluXis.Scoring.Enums;
-using fluXis.Scoring.Structs;
 using Newtonsoft.Json;
 
 namespace fluXis.Scoring;
@@ -10,79 +8,17 @@ namespace fluXis.Scoring;
 
 public class ScoreInfo
 {
-    [JsonProperty("accuracy")]
-    public float Accuracy { get; set; }
-
-    [JsonProperty("grade")]
-    public ScoreRank Rank { get; set; }
-
-    [JsonProperty("score")]
-    public int Score { get; set; }
-
-    [JsonProperty("pr")]
-    public double PerformanceRating { get; set; }
-
-    [JsonProperty("combo")]
-    public int Combo { get; set; }
-
-    [JsonProperty("maxCombo")]
-    public int MaxCombo { get; set; }
-
-    [JsonProperty("flawless")]
-    public int Flawless { get; set; }
-
-    [JsonProperty("perfect")]
-    public int Perfect { get; set; }
-
-    [JsonProperty("great")]
-    public int Great { get; set; }
-
-    [JsonProperty("alright")]
-    public int Alright { get; set; }
-
-    [JsonProperty("okay")]
-    public int Okay { get; set; }
-
-    [JsonProperty("miss")]
-    public int Miss { get; set; }
-
-    [JsonProperty("results")]
-    public List<HitResult>? HitResults { get; set; } = new();
-
     [JsonProperty("mapid")]
     public long MapID { get; set; }
-
-    [JsonProperty("player")]
-    public long PlayerID { get; set; }
 
     [JsonProperty("mods")]
     public List<string> Mods { get; set; } = new();
 
-    [JsonProperty("scrollspeed")]
-    public float ScrollSpeed { get; set; }
-
     [JsonProperty("time")]
     public long Timestamp { get; set; }
 
-    [JsonIgnore]
-    public long Ratio
-    {
-        get
-        {
-            var nonFlawless = Perfect + Great + Alright + Okay + Miss;
-
-            if (nonFlawless == 0)
-                return 0;
-
-            return Flawless * 100 / nonFlawless;
-        }
-    }
-
-    [JsonIgnore]
-    public bool FullFlawless => Flawless == MaxCombo;
-
-    [JsonIgnore]
-    public bool FullCombo => Miss == 0;
+    [JsonProperty("players")]
+    public List<PlayerScore> Players { get; set; } = new();
 
     [JsonIgnore]
     public float Rate

--- a/fluXis/Scoring/ScorePair.cs
+++ b/fluXis/Scoring/ScorePair.cs
@@ -1,0 +1,16 @@
+using fluXis.Database.Score;
+
+namespace fluXis.Scoring;
+
+//this is needed by ScoreListTab in order to actually obtain the PlayerScoreInfos for each scores
+public class ScorePair
+{
+    public ScoreInfo ScoreInfo;
+    public RealmScore RealmScore;
+
+    public ScorePair(ScoreInfo scoreInfo, RealmScore realmScore)
+    {
+        ScoreInfo = scoreInfo;
+        RealmScore = realmScore;
+    }
+}

--- a/fluXis/Screens/Gameplay/HUD/Leaderboard/GameplayLeaderboard.cs
+++ b/fluXis/Screens/Gameplay/HUD/Leaderboard/GameplayLeaderboard.cs
@@ -44,7 +44,11 @@ public partial class GameplayLeaderboard : Container<LeaderboardEntry>
         Padding = new MarginPadding(20);
         AlwaysPresent = true;
 
-        InternalChildrenEnumerable = scores.Take(10).Select(s => new LeaderboardEntry(this, s)).OrderDescending();
+        InternalChildrenEnumerable = scores.Take(10).Select(s =>
+        {
+            //TODO: find a way to select both players for dual map, or only select one side?
+            return new LeaderboardEntry(this, s.Players[0]);
+        }).OrderDescending();
 
         playfields.Players.ForEach(p => AddInternal(new SelfLeaderboardEntry(this, p.ScoreProcessor)));
     }

--- a/fluXis/Screens/Gameplay/HUD/Leaderboard/LeaderboardEntry.cs
+++ b/fluXis/Screens/Gameplay/HUD/Leaderboard/LeaderboardEntry.cs
@@ -26,7 +26,7 @@ public partial class LeaderboardEntry : CompositeDrawable, IComparable<Leaderboa
     private UserCache users { get; set; }
 
     private GameplayLeaderboard leaderboard { get; }
-    private ScoreInfo score { get; }
+    private PlayerScore score { get; }
 
     public float TargetY { get; set; }
 
@@ -35,7 +35,7 @@ public partial class LeaderboardEntry : CompositeDrawable, IComparable<Leaderboa
     private float lastScore;
     private double lastPr;
 
-    public LeaderboardEntry(GameplayLeaderboard leaderboard, ScoreInfo score)
+    public LeaderboardEntry(GameplayLeaderboard leaderboard, PlayerScore score)
     {
         this.leaderboard = leaderboard;
         this.score = score;

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/PlayfieldPlayer.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/PlayfieldPlayer.cs
@@ -34,8 +34,11 @@ public partial class PlayfieldPlayer : CompositeDrawable, IHUDDependencyProvider
 
     private DependencyContainer dependencies;
 
+    private readonly int index;
+
     public PlayfieldPlayer(int index, int subCount)
     {
+        this.index = index;
         MainPlayfield = new Playfield(index, 0);
         SubPlayfields = Enumerable.Range(1, subCount).Select(x => new Playfield(index, x)).ToArray();
     }
@@ -55,6 +58,7 @@ public partial class PlayfieldPlayer : CompositeDrawable, IHUDDependencyProvider
                 Player = ruleset.CurrentPlayer ?? APIUser.Default,
                 HitWindows = ruleset.HitWindows,
                 MapInfo = ruleset.MapInfo,
+                MapMaxCombo = ruleset.MapInfo.MaxComboForPlayer(index),
                 Mods = ruleset.Mods
             }
         });
@@ -71,7 +75,7 @@ public partial class PlayfieldPlayer : CompositeDrawable, IHUDDependencyProvider
     {
         base.LoadComplete();
 
-        JudgementProcessor.ApplyMap(ruleset.MapInfo);
+        JudgementProcessor.ApplyMap(ruleset.MapInfo, index);
         HealthProcessor.OnSavedDeath += () => samples?.EarlyFail();
         ScoreProcessor.OnComboBreak += () =>
         {

--- a/fluXis/Screens/Multiplayer/Gameplay/MultiGameplayScreen.cs
+++ b/fluXis/Screens/Multiplayer/Gameplay/MultiGameplayScreen.cs
@@ -75,12 +75,13 @@ public partial class MultiGameplayScreen : GameplayScreen
     {
         Scheduler.ScheduleIfNeeded(() =>
         {
-            var si = client.Room?.Scores?.FirstOrDefault(s => s.PlayerID == user);
+            var si = client.Room?.Scores?.FirstOrDefault(s => s.Players.Any(p => p.PlayerID == user));
 
             if (si is null)
                 return;
 
-            si.Score = score;
+            var playerScore = si.Players.First(p => p.PlayerID == user);
+            playerScore.Score = score;
         });
     }
 

--- a/fluXis/Screens/Multiplayer/Gameplay/MultiplayerResults.cs
+++ b/fluXis/Screens/Multiplayer/Gameplay/MultiplayerResults.cs
@@ -18,10 +18,13 @@ public partial class MultiplayerResults : Result.Results
     private MultiplayerClient client { get; }
 
     public MultiplayerResults(RealmMap map, List<ScoreInfo> scores, MultiplayerClient client)
-        : base(map, scores.FirstOrDefault(x => x.PlayerID == client.Player.ID), client.Player)
+        : base(map, scores.FirstOrDefault(s => s.Players.Any(p => p.PlayerID == client.Player.ID)))
     {
         this.scores = scores;
         this.client = client;
+
+        //if we are playing a dual map, we want to dipslay the stats of the side in which the client's user players
+        SelectedPlayer.Value = Score.Players.IndexOf(Score.Players.FirstOrDefault(x => x.PlayerID == client.Player.ID));
     }
 
     protected override Drawable[] CreateRightContent() => new Drawable[]
@@ -38,7 +41,8 @@ public partial class MultiplayerResults : Result.Results
 
         public Leaderboard(List<ScoreInfo> scores, MultiplayerClient client)
         {
-            this.scores = scores.OrderByDescending(x => x.Score).ToList();
+            //TODO: assume player 0 for now, needs more work for dual maps (maybe use sum of both sides)
+            this.scores = scores.OrderByDescending(x => x.Players[0].Score).ToList();
             this.client = client;
         }
 
@@ -48,11 +52,12 @@ public partial class MultiplayerResults : Result.Results
             AutoSizeAxes = Axes.Y,
             Direction = FillDirection.Vertical,
             Spacing = new Vector2(16),
+            //TODO: assume player 0 for now, needs more work for dual maps
             ChildrenEnumerable = scores.Select((x, i) =>
             {
-                var player = client.Room.Participants.FirstOrDefault(y => y.ID == x.PlayerID);
+                var player = client.Room.Participants.FirstOrDefault(y => y.ID == x.Players[0].PlayerID); //find a way to display both names for dual maps
                 var place = i + 1;
-                return new ResultsSideDoubleText($"#{place} {player?.Player.PreferredName ?? "??"}", x.Score.ToString("000000"));
+                return new ResultsSideDoubleText($"#{place} {player?.Player.PreferredName ?? "??"}", x.Players[0].Score.ToString("000000")); //display sum for dual maps?
             })
         };
     }

--- a/fluXis/Screens/Multiplayer/Gameplay/Results/MultiResultsScore.cs
+++ b/fluXis/Screens/Multiplayer/Gameplay/Results/MultiResultsScore.cs
@@ -96,15 +96,16 @@ public partial class MultiResultsScore : CompositeDrawable
                 Spacing = new Vector2(20),
                 Anchor = Anchor.CentreRight,
                 Origin = Anchor.CentreRight,
+                //TODO: concider dual maps
                 Children = new Drawable[]
                 {
-                    new TextContainer(score.Flawless.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Flawless) },
-                    new TextContainer(score.Perfect.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Perfect) },
-                    new TextContainer(score.Great.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Great) },
-                    new TextContainer(score.Alright.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Alright) },
-                    new TextContainer(score.Okay.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Okay) },
-                    new TextContainer(score.Miss.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Miss) },
-                    new TextContainer($"{score.MaxCombo}x"),
+                    new TextContainer(score.Players[0].Flawless.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Flawless) },
+                    new TextContainer(score.Players[0].Perfect.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Perfect) },
+                    new TextContainer(score.Players[0].Great.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Great) },
+                    new TextContainer(score.Players[0].Alright.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Alright) },
+                    new TextContainer(score.Players[0].Okay.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Okay) },
+                    new TextContainer(score.Players[0].Miss.ToString()) { Colour = skinManager.SkinJson.GetColorForJudgement(Judgement.Miss) },
+                    new TextContainer($"{score.Players[0].MaxCombo}x"),
                     new ScoreAcc(score)
                 }
             }
@@ -140,18 +141,19 @@ public partial class MultiResultsScore : CompositeDrawable
             Direction = FillDirection.Vertical;
             Spacing = new Vector2(-8);
 
+            //TODO: concider dual maps
             InternalChildren = new Drawable[]
             {
                 new FluXisSpriteText
                 {
-                    Text = $"{score.Score:0000000}",
+                    Text = $"{score.Players[0].Score:0000000}",
                     WebFontSize = 24,
                     Anchor = Anchor.CentreRight,
                     Origin = Anchor.CentreRight
                 },
                 new FluXisSpriteText
                 {
-                    Text = $"{score.Accuracy.ToStringInvariant("00.00")}%",
+                    Text = $"{score.Players[0].Accuracy.ToStringInvariant("00.00")}%",
                     WebFontSize = 16,
                     Alpha = .8f,
                     Anchor = Anchor.CentreRight,

--- a/fluXis/Screens/Multiplayer/Gameplay/Results/MultiResultsScores.cs
+++ b/fluXis/Screens/Multiplayer/Gameplay/Results/MultiResultsScores.cs
@@ -14,9 +14,10 @@ public partial class MultiResultsScores : FluXisScrollContainer
 {
     private List<ScoreInfo> scores { get; }
 
+    //TODO: concider dual maps (maybe we want to use the sum of the score of both sides)
     public MultiResultsScores(List<ScoreInfo> scores)
     {
-        this.scores = scores.OrderByDescending(score => score.Score).ToList();
+        this.scores = scores.OrderByDescending(score => score.Players[0].Score).ToList();
     }
 
     [BackgroundDependencyLoader]
@@ -32,7 +33,7 @@ public partial class MultiResultsScores : FluXisScrollContainer
             Direction = FillDirection.Vertical,
             Padding = new MarginPadding(40),
             Spacing = new Vector2(0, 10),
-            ChildrenEnumerable = scores.Select(score => new MultiResultsScore(score, users.Get(score.PlayerID), scores.IndexOf(score) + 1))
+            ChildrenEnumerable = scores.Select(score => new MultiResultsScore(score, users.Get(score.Players[0].PlayerID), scores.IndexOf(score) + 1)) //TODO: pass both players for dual maps?
         };
     }
 }

--- a/fluXis/Screens/Result/Center/ResultsCenterScore.cs
+++ b/fluXis/Screens/Result/Center/ResultsCenterScore.cs
@@ -9,17 +9,28 @@ namespace fluXis.Screens.Result.Center;
 
 public partial class ResultsCenterScore : CompositeDrawable
 {
+    [Resolved]
+    private Results results { get; set; }
+
+    [Resolved]
+    private ScoreInfo score { get; set; }
+
+    private ForcedHeightText scoreText;
+    private ForcedHeightText differenceText;
+
     [BackgroundDependencyLoader]
-    private void load(Results results, ScoreInfo score)
+    private void load()
     {
         RelativeSizeAxes = Axes.X;
         AutoSizeAxes = Axes.Y;
         Margin = new MarginPadding { Top = 36 };
 
+        int playerIndex = results.SelectedPlayer.Value;
+
         var difference = "";
 
         if (results.ComparisonScore != null)
-            difference = $"{score.Score - results.ComparisonScore.Score:+#0;-#0}";
+            difference = $"{score.Players[playerIndex].Score - results.ComparisonScore.Players[0].Score:+#0;-#0}"; //TODO: better logic for dual maps
 
         InternalChild = new FillFlowContainer
         {
@@ -39,16 +50,16 @@ public partial class ResultsCenterScore : CompositeDrawable
                     Origin = Anchor.Centre,
                     Alpha = .8f
                 },
-                new ForcedHeightText
+                scoreText = new ForcedHeightText
                 {
-                    Text = $"{score.Score:000000}",
+                    Text = $"{score.Players[playerIndex].Score:000000}",
                     WebFontSize = 64,
                     Height = 48,
                     Shadow = true,
                     Anchor = Anchor.Centre,
                     Origin = Anchor.Centre
                 },
-                new ForcedHeightText
+                differenceText = new ForcedHeightText
                 {
                     Text = difference,
                     WebFontSize = 24,
@@ -60,5 +71,18 @@ public partial class ResultsCenterScore : CompositeDrawable
                 }
             }
         };
+
+        results.SelectedPlayer.BindValueChanged(v => updateContentForPlayer(v.NewValue));
+    }
+
+    private void updateContentForPlayer(int playerIndex)
+    {
+        var difference = "";
+
+        if (results.ComparisonScore != null)
+            difference = $"{score.Players[playerIndex].Score - results.ComparisonScore.Players[0].Score:+#0;-#0}"; //TODO: better logic for dual maps
+
+        scoreText.Text = $"{score.Players[playerIndex].Score:000000}";
+        differenceText.Text = difference;
     }
 }

--- a/fluXis/Screens/Result/Center/ResultsCenterStats.cs
+++ b/fluXis/Screens/Result/Center/ResultsCenterStats.cs
@@ -13,12 +13,28 @@ namespace fluXis.Screens.Result.Center;
 
 public partial class ResultsCenterStats : CompositeDrawable
 {
+    [Resolved]
+    private Results results { get; set; }
+
+    [Resolved]
+    private RealmMap map { get; set; }
+
+    [Resolved]
+    private ScoreInfo score { get; set; }
+
     [BackgroundDependencyLoader]
-    private void load(RealmMap map, ScoreInfo score)
+    private void load()
     {
         RelativeSizeAxes = Axes.X;
         Height = 38;
 
+        makeContentForPlayer(results.SelectedPlayer.Value);
+
+        results.SelectedPlayer.BindValueChanged(v => makeContentForPlayer(v.NewValue));
+    }
+
+    private void makeContentForPlayer(int playerIndex)
+    {
         InternalChild = new GridContainer
         {
             RelativeSizeAxes = Axes.Both,
@@ -26,17 +42,17 @@ public partial class ResultsCenterStats : CompositeDrawable
             {
                 new Drawable[]
                 {
-                    new Statistic("Accuracy", $"{score.Accuracy.ToStringInvariant("00.00")}%"),
+                    new Statistic("Accuracy", $"{score.Players[playerIndex].Accuracy.ToStringInvariant("00.00")}%"),
                     new Statistic("Combo", "", flow =>
                     {
-                        flow.AddText($"{score.MaxCombo}x");
+                        flow.AddText($"{score.Players[playerIndex].MaxCombo}x");
                         flow.AddText<FluXisSpriteText>($"/{map.Filters.NoteCount + map.Filters.LongNoteCount * 2}x", text =>
                         {
                             text.WebFontSize = 14;
                             text.Alpha = .6f;
                         });
                     }),
-                    new Statistic("Performance", $"{score.PerformanceRating.ToStringInvariant("0.00")}"),
+                    new Statistic("Performance", $"{score.Players[playerIndex].PerformanceRating.ToStringInvariant("0.00")}"),
                 }
             }
         };

--- a/fluXis/Screens/Result/Header/ResultsPlayer.cs
+++ b/fluXis/Screens/Result/Header/ResultsPlayer.cs
@@ -1,6 +1,7 @@
 ﻿using fluXis.Graphics;
 using fluXis.Graphics.Containers;
 using fluXis.Graphics.Sprites.Text;
+using fluXis.Graphics.UserInterface.Color;
 using fluXis.Online.API.Models.Users;
 using fluXis.Online.Drawables.Clubs;
 using fluXis.Online.Drawables.Images;
@@ -22,11 +23,22 @@ public partial class ResultsPlayer : CompositeDrawable
     private ScoreInfo score { get; set; }
 
     [Resolved]
-    private APIUser user { get; set; }
+    private Results results { get; set; }
+
+    private APIUser user;
+    private int playerIndex;
+
+    private FluXisSpriteText usernameText;
 
     [CanBeNull]
     [Resolved(CanBeNull = true)]
     private UserProfileOverlay overlay { get; set; }
+
+    public ResultsPlayer(APIUser user, int playerIndex)
+    {
+        this.user = user;
+        this.playerIndex = playerIndex;
+    }
 
     [BackgroundDependencyLoader]
     private void load()
@@ -34,6 +46,8 @@ public partial class ResultsPlayer : CompositeDrawable
         AutoSizeAxes = Axes.Both;
 
         var date = TimeUtils.GetFromSeconds(score.Timestamp);
+
+        var color = (playerIndex == results.SelectedPlayer.Value) ? Theme.Purple : Theme.Text;
 
         InternalChild = new FillFlowContainer
         {
@@ -81,11 +95,12 @@ public partial class ResultsPlayer : CompositeDrawable
                                     Origin = Anchor.CentreLeft,
                                     Shadow = true
                                 },
-                                new FluXisSpriteText
+                                usernameText = new FluXisSpriteText
                                 {
                                     Text = $" {user.Username}",
                                     Anchor = Anchor.CentreLeft,
                                     Origin = Anchor.CentreLeft,
+                                    Colour = color,
                                     WebFontSize = 20,
                                     Shadow = true
                                 }
@@ -104,11 +119,19 @@ public partial class ResultsPlayer : CompositeDrawable
                 }
             }
         };
+
+        results.SelectedPlayer.BindValueChanged(v => onResultSelectedPlayerChange(v.NewValue));
     }
 
     protected override bool OnClick(ClickEvent e)
     {
-        overlay?.ShowUser(user.ID);
+        if (results.SelectedPlayer.Value == playerIndex) overlay?.ShowUser(user.ID);
+        else results.SelectedPlayer.Value = playerIndex;
         return true;
+    }
+
+    private void onResultSelectedPlayerChange(int newPlayerIndex)
+    {
+        usernameText.Colour = newPlayerIndex == playerIndex ? Theme.Purple : Theme.Text;
     }
 }

--- a/fluXis/Screens/Result/ResultsHeader.cs
+++ b/fluXis/Screens/Result/ResultsHeader.cs
@@ -1,4 +1,6 @@
-﻿using fluXis.Screens.Result.Header;
+﻿using System.Collections.Generic;
+using fluXis.Online.API.Models.Users;
+using fluXis.Screens.Result.Header;
 using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
@@ -7,6 +9,9 @@ namespace fluXis.Screens.Result;
 
 public partial class ResultsHeader : CompositeDrawable
 {
+    [Resolved]
+    private List<APIUser> players { get; set; }
+
     [BackgroundDependencyLoader]
     private void load()
     {
@@ -17,11 +22,23 @@ public partial class ResultsHeader : CompositeDrawable
         InternalChildren = new Drawable[]
         {
             new ResultsMap(),
-            new ResultsPlayer
+        };
+
+        int x = -300 * (players.Count - 1);
+        int i = 0;
+
+        foreach (var player in players)
+        {
+            AddInternal(new ResultsPlayer(player, i)
             {
                 Anchor = Anchor.TopRight,
-                Origin = Anchor.TopRight
-            }
-        };
+                Origin = Anchor.TopRight,
+                X = x,
+            });
+            x += 300;
+            i++;
+        }
     }
+
+    //TODO: update this whenever we switch scoreInfo in the result screen
 }

--- a/fluXis/Screens/Result/Sides/Types/ResultsSideGraph.cs
+++ b/fluXis/Screens/Result/Sides/Types/ResultsSideGraph.cs
@@ -27,11 +27,13 @@ public partial class ResultsSideGraph : ResultsSideContainer
 
     private ScoreInfo score { get; }
     private RealmMap map { get; }
+    private int selectedPlayer { get; }
 
-    public ResultsSideGraph(ScoreInfo score, RealmMap map)
+    public ResultsSideGraph(ScoreInfo score, RealmMap map, int selectedPlayer = 0)
     {
         this.score = score;
         this.map = map;
+        this.selectedPlayer = selectedPlayer;
     }
 
     protected override Drawable CreateContent() => new LoadWrapper<GraphContainer>
@@ -40,7 +42,7 @@ public partial class ResultsSideGraph : ResultsSideContainer
         AutoSizeAxes = Axes.Y,
         AutoSizeDuration = 400,
         AutoSizeEasing = Easing.Out,
-        LoadContent = () => new GraphContainer(score, map),
+        LoadContent = () => new GraphContainer(score, map, selectedPlayer),
         OnComplete = g => g.FadeInFromZero(400)
     };
 
@@ -48,11 +50,13 @@ public partial class ResultsSideGraph : ResultsSideContainer
     {
         private RealmMap map { get; }
         private ScoreInfo score { get; }
+        private int selectedPlayer { get; }
 
-        public GraphContainer(ScoreInfo score, RealmMap map)
+        public GraphContainer(ScoreInfo score, RealmMap map, int selectedPlayer = 0)
         {
             this.score = score;
             this.map = map;
+            this.selectedPlayer = selectedPlayer;
         }
 
         [BackgroundDependencyLoader]
@@ -76,7 +80,7 @@ public partial class ResultsSideGraph : ResultsSideContainer
                     AutoSizeAxes = Axes.Y,
                     Padding = new MarginPadding { Left = 15 },
                     Margin = new MarginPadding { Left = 10 },
-                    Child = new Graph(score, map)
+                    Child = new Graph(score, map, selectedPlayer)
                 },
                 new Container
                 {
@@ -161,11 +165,13 @@ public partial class ResultsSideGraph : ResultsSideContainer
 
         private RealmMap map { get; }
         private ScoreInfo score { get; }
+        private int selectedPlayer { get; }
 
-        public Graph(ScoreInfo score, RealmMap map)
+        public Graph(ScoreInfo score, RealmMap map, int selectedPlayer)
         {
             this.score = score;
             this.map = map;
+            this.selectedPlayer = selectedPlayer;
         }
 
         [BackgroundDependencyLoader]
@@ -188,20 +194,20 @@ public partial class ResultsSideGraph : ResultsSideContainer
                 var timing = timings[i];
                 var color = skins.SkinJson.GetColorForJudgement(timing.Judgement);
                 var lineColor = new Color(new Rgba32(color.Opacity(0.4f).Vector));
-                
+
                 var yEarly = miss - 1 - timing.Milliseconds;
                 if (yEarly >= 0)
                     image.Mutate(ctx => ctx.DrawLine(lineColor, 2, new PointF(0, yEarly), new PointF(image.Width, yEarly)));
-                
+
                 var yLate = miss - 1 + timing.Milliseconds;
                 if (yLate < image.Height)
                     image.Mutate(ctx => ctx.DrawLine(lineColor, 2, new PointF(0, yLate), new PointF(image.Width, yLate)));
             }
 
-            var start = score.HitResults.MinBy(x => x.Time).Time;
-            var end = score.HitResults.MaxBy(x => x.Time).Time - start;
+            var start = score.Players[selectedPlayer].HitResults.MinBy(x => x.Time).Time;
+            var end = score.Players[selectedPlayer].HitResults.MaxBy(x => x.Time).Time - start;
 
-            var misses = score.HitResults.Where(x => x.Judgement == Judgement.Miss).ToList();
+            var misses = score.Players[selectedPlayer].HitResults.Where(x => x.Judgement == Judgement.Miss).ToList();
 
             foreach (var result in misses)
             {
@@ -211,7 +217,7 @@ public partial class ResultsSideGraph : ResultsSideContainer
                 image.Mutate(ctx => ctx.Fill(new Color(new Rgba32(color.Opacity(.4f).Vector)), new RectangleF(x - 2, 0, 4, image.Height)));
             }
 
-            foreach (var result in score.HitResults)
+            foreach (var result in score.Players[selectedPlayer].HitResults)
             {
                 var color = skins.SkinJson.GetColorForJudgement(result.Judgement);
 

--- a/fluXis/Screens/Result/Sides/Types/ResultsSideJudgements.cs
+++ b/fluXis/Screens/Result/Sides/Types/ResultsSideJudgements.cs
@@ -15,11 +15,13 @@ public partial class ResultsSideJudgements : ResultsSideContainer
 
     private ISkin skin { get; }
     private ScoreInfo score { get; }
+    private int selectedPlayer { get; set; }
 
-    public ResultsSideJudgements(ISkin skin, ScoreInfo score)
+    public ResultsSideJudgements(ISkin skin, ScoreInfo score, int selectedPlayer)
     {
         this.score = score;
         this.skin = skin;
+        this.selectedPlayer = (selectedPlayer >= score.Players.Count) ? 0 : selectedPlayer;
     }
 
     protected override Drawable CreateContent() => new FillFlowContainer
@@ -30,12 +32,12 @@ public partial class ResultsSideJudgements : ResultsSideContainer
         Spacing = new Vector2(16),
         Children = new Drawable[]
         {
-            new ResultsSideDoubleText("Flawless", $"{score.Flawless}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Flawless) },
-            new ResultsSideDoubleText("Perfect", $"{score.Perfect}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Perfect) },
-            new ResultsSideDoubleText("Great", $"{score.Great}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Great) },
-            new ResultsSideDoubleText("Alright", $"{score.Alright}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Alright) },
-            new ResultsSideDoubleText("Okay", $"{score.Okay}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Okay) },
-            new ResultsSideDoubleText("Miss", $"{score.Miss}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Miss) },
+            new ResultsSideDoubleText("Flawless", $"{score.Players[selectedPlayer].Flawless}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Flawless) },
+            new ResultsSideDoubleText("Perfect", $"{score.Players[selectedPlayer].Perfect}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Perfect) },
+            new ResultsSideDoubleText("Great", $"{score.Players[selectedPlayer].Great}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Great) },
+            new ResultsSideDoubleText("Alright", $"{score.Players[selectedPlayer].Alright}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Alright) },
+            new ResultsSideDoubleText("Okay", $"{score.Players[selectedPlayer].Okay}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Okay) },
+            new ResultsSideDoubleText("Miss", $"{score.Players[selectedPlayer].Miss}") { Colour = skin.SkinJson.GetColorForJudgement(Judgement.Miss) },
         }
     };
 }

--- a/fluXis/Screens/Result/Sides/Types/ResultsSideMore.cs
+++ b/fluXis/Screens/Result/Sides/Types/ResultsSideMore.cs
@@ -15,10 +15,12 @@ public partial class ResultsSideMore : ResultsSideContainer
     protected override LocalisableString Title => "More Info";
 
     private ScoreInfo score { get; }
+    private int selectedPlayer { get; }
 
-    public ResultsSideMore(ScoreInfo score)
+    public ResultsSideMore(ScoreInfo score, int selectedPlayer)
     {
         this.score = score;
+        this.selectedPlayer = (selectedPlayer >= score.Players.Count) ? selectedPlayer - 1 : selectedPlayer;
     }
 
     protected override Drawable CreateContent()
@@ -31,21 +33,21 @@ public partial class ResultsSideMore : ResultsSideContainer
             Spacing = new Vector2(16)
         };
 
-        flow.Add(new ResultsSideDoubleText("FL:PF Ratio", score.Flawless switch
+        flow.Add(new ResultsSideDoubleText("FL:PF Ratio", score.Players[selectedPlayer].Flawless switch
         {
             0 => "0",
-            > 0 when score.Perfect == 0 => "Full Flawless",
-            _ => $"{(score.Flawless / (float)score.Perfect).ToStringInvariant("0.0")}:1"
+            > 0 when score.Players[selectedPlayer].Perfect == 0 => "Full Flawless",
+            _ => $"{(score.Players[selectedPlayer].Flawless / (float)score.Players[selectedPlayer].Perfect).ToStringInvariant("0.0")}:1"
         }));
 
-        if (score.HitResults is { Count: > 0 })
+        if (score.Players[selectedPlayer].HitResults is { Count: > 0 })
         {
-            var nonMiss = score.HitResults.Where(r => r.Judgement > Judgement.Miss).ToList();
+            var nonMiss = score.Players[selectedPlayer].HitResults.Where(r => r.Judgement > Judgement.Miss).ToList();
             var avg = nonMiss.Count > 1 ? nonMiss.Average(x => x.Difference) : 0;
             flow.Add(new ResultsSideDoubleText("Mean", $"{(int)-avg}ms"));
         }
 
-        flow.Add(new ResultsSideDoubleText("Scroll Speed", $"{score.ScrollSpeed.ToStringInvariant()}"));
+        flow.Add(new ResultsSideDoubleText("Scroll Speed", $"{score.Players[selectedPlayer].ScrollSpeed.ToStringInvariant()}"));
         return flow;
     }
 }

--- a/fluXis/Screens/Result/SoloResults.cs
+++ b/fluXis/Screens/Result/SoloResults.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using fluXis.Database.Maps;
-using fluXis.Online.API.Models.Users;
 using fluXis.Online.API.Requests.Scores;
 using fluXis.Scoring;
 using fluXis.Screens.Result.Sides.Types;
@@ -15,8 +14,8 @@ public partial class SoloResults : Results
 
     public ScoreSubmitRequest SubmitRequest { get; set; }
 
-    public SoloResults(RealmMap map, ScoreInfo score, APIUser player)
-        : base(map, score, player)
+    public SoloResults(RealmMap map, ScoreInfo score)
+        : base(map, score)
     {
     }
 

--- a/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListEntry.cs
+++ b/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListEntry.cs
@@ -52,6 +52,8 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
     [Resolved(CanBeNull = true)]
     private UserProfileOverlay profileOverlay { get; set; }
 
+    public int PlayerIndex { get; set; } = 0;
+
     public MenuItem[] ContextMenuItems
     {
         get
@@ -130,7 +132,7 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
                 rankBackground = new Box
                 {
                     RelativeSizeAxes = Axes.Both,
-                    Colour = DrawableScoreRank.GetColor(ScoreInfo.Rank, true)
+                    Colour = DrawableScoreRank.GetColor(ScoreInfo.Players[PlayerIndex].Rank, true)
                 },
                 new Container
                 {
@@ -292,14 +294,14 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
                                                     {
                                                         new FluXisSpriteText
                                                         {
-                                                            Text = ScoreInfo.Accuracy.ToString("00.00").Replace(",", ".") + "%",
+                                                            Text = ScoreInfo.Players[PlayerIndex].Accuracy.ToString("00.00").Replace(",", ".") + "%",
                                                             WebFontSize = 12,
                                                             Anchor = Anchor.CentreLeft,
                                                             Origin = Anchor.CentreLeft
                                                         },
                                                         new FluXisSpriteText
                                                         {
-                                                            Text = $"{ScoreInfo.MaxCombo}x",
+                                                            Text = $"{ScoreInfo.Players[PlayerIndex].MaxCombo}x",
                                                             WebFontSize = 12,
                                                             Anchor = Anchor.CentreLeft,
                                                             Origin = Anchor.CentreLeft,
@@ -321,14 +323,14 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
                                             {
                                                 new FluXisSpriteText
                                                 {
-                                                    Text = $"{ScoreInfo.PerformanceRating.ToStringInvariant("00.00")}pr",
+                                                    Text = $"{ScoreInfo.Players[PlayerIndex].PerformanceRating.ToStringInvariant("00.00")}pr",
                                                     WebFontSize = 20,
                                                     Anchor = Anchor.CentreRight,
                                                     Origin = Anchor.CentreRight
                                                 },
                                                 new FluXisSpriteText
                                                 {
-                                                    Text = ScoreInfo.Score.ToString("0000000"),
+                                                    Text = ScoreInfo.Players[PlayerIndex].Score.ToString("0000000"),
                                                     WebFontSize = 14,
                                                     Anchor = Anchor.CentreRight,
                                                     Origin = Anchor.CentreRight,
@@ -349,7 +351,7 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
                     Origin = Anchor.CentreRight,
                     Child = new DrawableScoreRank
                     {
-                        Rank = ScoreInfo.Rank,
+                        Rank = ScoreInfo.Players[PlayerIndex].Rank,
                         FontSize = FluXisSpriteText.GetWebFontSize(28),
                         Shadow = false,
                         AlternateColor = true,
@@ -378,7 +380,7 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
                .Then((Place - 1) * 50)
                .MoveToX(0, 600, Easing.OutQuint).FadeIn(300);
 
-        if (ScoreInfo.Rank == ScoreRank.X)
+        if (ScoreInfo.Players[PlayerIndex].Rank == ScoreRank.X)
             rankBackground.Rainbow();
     }
 
@@ -511,12 +513,13 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
         }
     }
 
-    private void viewDetails() => game.PresentScore(Map, ScoreInfo, Player, ReplayAction);
+    private void viewDetails() => game.PresentScore(Map, ScoreInfo, ReplayAction);
 
-    public ITooltip<ScoreInfo> GetCustomTooltip() => new ScoreListEntryTooltip();
+    public ITooltip<ScoreInfo> GetCustomTooltip() => new ScoreListEntryTooltip(PlayerIndex);
 
     private partial class ScoreListEntryTooltip : CustomTooltipContainer<ScoreInfo>
     {
+        private int playerIndex;
         private ForcedHeightText dateText { get; }
         private ForcedHeightText dateAgoText { get; }
         private TooltipRow flawlessText { get; }
@@ -526,8 +529,10 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
         private TooltipRow okayText { get; }
         private TooltipRow missText { get; }
 
-        public ScoreListEntryTooltip()
+        public ScoreListEntryTooltip(int playerIndex)
         {
+            this.playerIndex = playerIndex;
+
             CornerRadius = 10;
             Child = new FillFlowContainer
             {
@@ -590,17 +595,19 @@ public partial class ScoreListEntry : Container, IHasCustomTooltip<ScoreInfo>, I
 
         public override void SetContent(ScoreInfo score)
         {
+            if (score.Players == null || playerIndex >= score.Players.Count) return;
+
             var date = TimeUtils.GetFromSeconds(score.Timestamp);
 
             dateText.Text = $"{date:dd MMMM yyyy} @ {date:HH:mm}";
             dateAgoText.Text = TimeUtils.Ago(date);
 
-            flawlessText.Text = $"{score.Flawless}";
-            perfectText.Text = $"{score.Perfect}";
-            greatText.Text = $"{score.Great}";
-            alrightText.Text = $"{score.Alright}";
-            okayText.Text = $"{score.Okay}";
-            missText.Text = $"{score.Miss}";
+            flawlessText.Text = $"{score.Players[playerIndex].Flawless}";
+            perfectText.Text = $"{score.Players[playerIndex].Perfect}";
+            greatText.Text = $"{score.Players[playerIndex].Great}";
+            alrightText.Text = $"{score.Players[playerIndex].Alright}";
+            okayText.Text = $"{score.Players[playerIndex].Okay}";
+            missText.Text = $"{score.Players[playerIndex].Miss}";
         }
     }
 

--- a/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListTab.cs
+++ b/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListTab.cs
@@ -288,7 +288,7 @@ public partial class ScoreListTab : SelectInfoTab
             default:
                 if (map.OnlineID == -1)
                     replaceNoScores(LocalizationStrings.SongSelect.LeaderboardNotUploaded);
-                else if (tryFetchScores(type.Value, cancelToken, out var s)) //TODO: request dual maps
+                else if (tryFetchScores(type.Value, cancelToken, selectedPlayer.Value, out var s)) //TODO: request dual maps
                     scores.AddRange(s);
                 else
                     return;
@@ -345,7 +345,7 @@ public partial class ScoreListTab : SelectInfoTab
         }
     }
 
-    private bool tryFetchScores(ScoreListType type, CancellationToken cancelToken, out List<ScoreListEntry> scores)
+    private bool tryFetchScores(ScoreListType type, CancellationToken cancelToken, int playerIndex, out List<ScoreListEntry> scores)
     {
         scores = new List<ScoreListEntry>();
 
@@ -355,7 +355,7 @@ public partial class ScoreListTab : SelectInfoTab
             return false;
         }
 
-        var req = new MapLeaderboardRequest(type, map.OnlineID);
+        var req = new MapLeaderboardRequest(type, map.OnlineID, playerIndex);
         api.PerformRequest(req);
 
         if (cancelToken.IsCancellationRequested)

--- a/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListTab.cs
+++ b/fluXis/Screens/Select/Info/Tabs/Scores/ScoreListTab.cs
@@ -75,6 +75,9 @@ public partial class ScoreListTab : SelectInfoTab
     private FillFlowContainer outOfDate;
 
     private RealmMap map;
+    private readonly Bindable<int> selectedPlayer = new(0);
+    private readonly Bindable<int> playerCount = new(1);
+
     private readonly Bindable<ScoreListType> type = new();
     private readonly Bindable<string> username = new();
 
@@ -229,6 +232,8 @@ public partial class ScoreListTab : SelectInfoTab
         if (map is null) return;
 
         cancel = cancelSource.Token;
+        selectedPlayer.Value = 0;
+        playerCount.Value = 1;
         Task.Run(() => loadScores(cancel), cancel);
     }
 
@@ -239,12 +244,19 @@ public partial class ScoreListTab : SelectInfoTab
         switch (type.Value)
         {
             case ScoreListType.Local:
-                scores.AddRange(scoreManager.OnMap(map.ID).Select(x =>
+                scores.AddRange(scoreManager.OnMap(map.ID).Select(pair =>
                 {
-                    var info = x.ToScoreInfo();
-                    var detach = x.Detach();
+                    var info = pair.ScoreInfo;
+                    var detach = pair.RealmScore.Detach();
 
-                    var player = users.Get(info.PlayerID);
+                    if (info.Players == null) throw new Exception("no players");
+
+                    if (info.Players.Count > playerCount.Value) playerCount.Value = info.Players.Count;
+
+                    //FIXME: if one of the score in the middle of the list is invalid this might cause issues
+                    if (selectedPlayer.Value >= info.Players.Count) selectedPlayer.Value = 0;
+
+                    var player = users.Get(info.Players[selectedPlayer.Value].PlayerID);
 
                     if (player is null)
                     {
@@ -261,13 +273,14 @@ public partial class ScoreListTab : SelectInfoTab
                         ScoreInfo = info,
                         Map = map,
                         Player = player,
+                        PlayerIndex = selectedPlayer.Value,
                         ShowSelfOutline = false,
                         DeleteAction = () =>
                         {
                             scoreManager.Delete(detach.ID);
                             Refresh();
                         },
-                        ReplayAction = replays.Exists(x.ID) ? () => screen?.ViewReplay(map, detach) : null
+                        ReplayAction = replays.Exists(pair.RealmScore.ID) ? () => screen?.ViewReplay(map, detach) : null
                     };
                 }));
                 break;
@@ -275,7 +288,7 @@ public partial class ScoreListTab : SelectInfoTab
             default:
                 if (map.OnlineID == -1)
                     replaceNoScores(LocalizationStrings.SongSelect.LeaderboardNotUploaded);
-                else if (tryFetchScores(type.Value, cancelToken, out var s))
+                else if (tryFetchScores(type.Value, cancelToken, out var s)) //TODO: request dual maps
                     scores.AddRange(s);
                 else
                     return;
@@ -290,8 +303,8 @@ public partial class ScoreListTab : SelectInfoTab
 
             scores.Sort((a, b) =>
             {
-                var res = b.ScoreInfo.PerformanceRating.CompareTo(a.ScoreInfo.PerformanceRating);
-                return res == 0 ? b.ScoreInfo.Score.CompareTo(a.ScoreInfo.Score) : res;
+                var res = b.ScoreInfo.Players[selectedPlayer.Value].PerformanceRating.CompareTo(a.ScoreInfo.Players[selectedPlayer.Value].PerformanceRating);
+                return res == 0 ? b.ScoreInfo.Players[selectedPlayer.Value].Score.CompareTo(a.ScoreInfo.Players[selectedPlayer.Value].Score) : res;
             });
 
             currentEntries.Clear();

--- a/fluXis/Screens/Select/List/Drawables/MapSet/DrawableMapSetDifficulty.cs
+++ b/fluXis/Screens/Select/List/Drawables/MapSet/DrawableMapSetDifficulty.cs
@@ -301,7 +301,7 @@ public partial class DrawableMapSetDifficulty : Container, IHasContextMenu, ICom
             return;
 
         rank.Alpha = score is null ? 0 : 1;
-        rank.Rank = score?.Rank ?? ScoreRank.D;
+        rank.Rank = score?.Players?[0].Rank ?? ScoreRank.D; //TODO: handle dual maps, assume player 0 for now
     }
 
     protected override bool OnClick(ClickEvent e)

--- a/fluXis/Utils/Extensions/APIExtensions.cs
+++ b/fluXis/Utils/Extensions/APIExtensions.cs
@@ -55,23 +55,34 @@ public static class APIExtensions
         return user.Groups.Any(g => g.ID == "moderators");
     }
 
-    public static ScoreInfo ToScoreInfo(this APIScore score) => new()
+    //TODO: support dual scores
+    public static ScoreInfo ToScoreInfo(this APIScore score)
     {
-        Accuracy = score.Accuracy,
-        Rank = (ScoreRank)Enum.Parse(typeof(ScoreRank), score.Rank),
-        Score = score.TotalScore,
-        PerformanceRating = score.PerformanceRating,
-        MaxCombo = score.MaxCombo,
-        Flawless = score.FlawlessCount,
-        Perfect = score.PerfectCount,
-        Great = score.GreatCount,
-        Alright = score.AlrightCount,
-        Okay = score.OkayCount,
-        Miss = score.MissCount,
-        MapID = score.Map?.ID ?? -1,
-        ScrollSpeed = score.ScrollSpeed,
-        Timestamp = score.Time,
-        Mods = score.Mods.Split(",").ToList(),
-        PlayerID = score.User.ID
-    };
+        ScoreInfo scoreInfo = new ScoreInfo
+        {
+            MapID = score.Map?.ID ?? -1,
+            Timestamp = score.Time,
+            Mods = score.Mods.Split(",").ToList(),
+        };
+
+        scoreInfo.Players ??= new List<PlayerScore>();
+        scoreInfo.Players.Add(new PlayerScore
+        {
+            Accuracy = score.Accuracy,
+            Rank = (ScoreRank)Enum.Parse(typeof(ScoreRank), score.Rank),
+            Score = score.TotalScore,
+            PerformanceRating = score.PerformanceRating,
+            MaxCombo = score.MaxCombo,
+            Flawless = score.FlawlessCount,
+            Perfect = score.PerfectCount,
+            Great = score.GreatCount,
+            Alright = score.AlrightCount,
+            Okay = score.OkayCount,
+            Miss = score.MissCount,
+            ScrollSpeed = score.ScrollSpeed,
+            PlayerID = score.User.ID
+        });
+
+        return scoreInfo;
+    }
 }

--- a/fluXis/Utils/Extensions/APIExtensions.cs
+++ b/fluXis/Utils/Extensions/APIExtensions.cs
@@ -55,7 +55,6 @@ public static class APIExtensions
         return user.Groups.Any(g => g.ID == "moderators");
     }
 
-    //TODO: support dual scores
     public static ScoreInfo ToScoreInfo(this APIScore score)
     {
         ScoreInfo scoreInfo = new ScoreInfo
@@ -66,6 +65,8 @@ public static class APIExtensions
         };
 
         scoreInfo.Players ??= new List<PlayerScore>();
+
+        //add main player
         scoreInfo.Players.Add(new PlayerScore
         {
             Accuracy = score.Accuracy,
@@ -82,6 +83,27 @@ public static class APIExtensions
             ScrollSpeed = score.ScrollSpeed,
             PlayerID = score.User.ID
         });
+
+        //add other players
+        foreach (var apiScoreExtraPlayer in score.ExtraPlayers)
+        {
+            scoreInfo.Players.Add(new PlayerScore
+            {
+                Accuracy = apiScoreExtraPlayer.Accuracy,
+                Rank = (ScoreRank)Enum.Parse(typeof(ScoreRank), apiScoreExtraPlayer.Rank),
+                Score = apiScoreExtraPlayer.TotalScore,
+                PerformanceRating = apiScoreExtraPlayer.PerformanceRating,
+                MaxCombo = apiScoreExtraPlayer.MaxCombo,
+                Flawless = apiScoreExtraPlayer.FlawlessCount,
+                Perfect = apiScoreExtraPlayer.PerfectCount,
+                Great = apiScoreExtraPlayer.GreatCount,
+                Alright = apiScoreExtraPlayer.AlrightCount,
+                Okay = apiScoreExtraPlayer.OkayCount,
+                Miss = apiScoreExtraPlayer.MissCount,
+                ScrollSpeed = apiScoreExtraPlayer.ScrollSpeed,
+                PlayerID = apiScoreExtraPlayer.User.ID,
+            });
+        }
 
         return scoreInfo;
     }


### PR DESCRIPTION
this pr contains some improvements for dual maps

this is far from being finished, but i'm opening this just in case anything in here end up actually being useful for anything in the future in case i don't actually finish this

- dual maps are now imported properly
- in order to store dual scores properly, i created a "PlayerScore" class, and moved all the scoring related stuff in there, and the ScoreInfo class new contains an array of PlayerScore
- the result screen can display the result of both players. it is possible to switch between players by clicking on the pfps at the top right, and clicking on the player that is already selected opens his profile in order to keep the old behaviour
- all players' scores should have a maximum value of 1000000 with no mods applied, and the easy/hard mods work properly

https://github.com/user-attachments/assets/34d22b3c-b584-4222-909b-9098a3001470


there are a few things that i want to do but are not there yet, such as
- fix the MaxCombo value being incorrect in the result screen
- add some sort of filters in the song select's leaderboard to allow getting the score for each sides separately, and also sorting by total score
- make it possible to create dual maps without having to edit the file manually
- ability to play dual maps in multiplayer
- actually write the realm migration (and fix the one i broke due to the changes)


fluxel branch (barely contains anything for now) : https://github.com/orwenn22/fluxel/tree/dual-iimprovements