### PR TITLE
Fix Gradient Appearing On InfoHeader

### DIFF
--- a/fluXis/Graphics/Containers/LoadWrapper.cs
+++ b/fluXis/Graphics/Containers/LoadWrapper.cs
@@ -4,11 +4,13 @@ using osu.Framework.Graphics.Containers;
 
 namespace fluXis.Graphics.Containers;
 
-public partial class LoadWrapper<T> : Container
+public partial class LoadWrapper<T> : Container, IHasLoadedValue
     where T : Drawable
 {
     public Action<T> OnComplete { get; init; }
     public Func<T> LoadContent { get; set; }
+
+    public bool Loaded { get; private set; }
 
     protected override void LoadComplete()
     {
@@ -23,6 +25,7 @@ public partial class LoadWrapper<T> : Container
         LoadComponentAsync(LoadContent(), drawable =>
         {
             Add(drawable);
+            Loaded = true;
             OnComplete?.Invoke(drawable);
         });
     }

--- a/fluXis/Graphics/Sprites/SpriteStack.cs
+++ b/fluXis/Graphics/Sprites/SpriteStack.cs
@@ -21,7 +21,7 @@ public partial class SpriteStack<T> : CompositeDrawable
     public void Add(T sprite, float duration = Styling.TRANSITION_FADE)
     {
         if (sprite is not IHasLoadedValue)
-            Current?.Delay(duration).Expire();
+            Current?.Delay(duration).FadeIn(duration).Expire();
 
         sprite.RelativeSizeAxes = Axes.Both;
         sprite.Anchor = sprite.Origin = Anchor.Centre;

--- a/fluXis/Graphics/Sprites/SpriteStack.cs
+++ b/fluXis/Graphics/Sprites/SpriteStack.cs
@@ -21,7 +21,7 @@ public partial class SpriteStack<T> : CompositeDrawable
     public void Add(T sprite, float duration = Styling.TRANSITION_FADE)
     {
         if (sprite is not IHasLoadedValue)
-            Current?.Delay(duration).FadeIn(duration).Expire();
+            Current?.Delay(duration).Expire();
 
         sprite.RelativeSizeAxes = Axes.Both;
         sprite.Anchor = sprite.Origin = Anchor.Centre;


### PR DESCRIPTION
A lot of times the gradient is visible on the header which makes it look ugly.

```cs
var background = new LoadWrapper<MapBackground>
        {
            RelativeSizeAxes = Axes.Both,
            LoadContent = () => new MapBackground(map) { RelativeSizeAxes = Axes.Both },
            OnComplete = b => b.FadeInFromZero(Styling.TRANSITION_FADE)
        };
        LoadComponent(background);
        backgrounds.Add(background);
```
Because here it is added to the sprite stack in sync not when on complete.
As an upside to adding a fade instead of just expiring (SpriteStack) is that it's smooth.