### PR TITLE
fix EditorTickNote

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Charting/Playfield/Objects/EditorTickNote.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Playfield/Objects/EditorTickNote.cs
@@ -17,8 +17,12 @@ public partial class EditorTickNote : EditorHitObject
 
     protected override IEnumerable<Drawable> CreateContent() => new[]
     {
-        tickNoteGhost = new DefaultTickNote(false).With(d => d.Alpha = .2f),
-        tickNotePiece = new DefaultTickNote(false)
+        tickNoteGhost = new DefaultTickNote(false).With(d =>
+        {
+            d.Alpha = .2f;
+            d.RelativeSizeAxes = Axes.X;
+        }),
+        tickNotePiece = new DefaultTickNote(false).With(d => d.RelativeSizeAxes = Axes.X)
     };
 
     protected override void Update()


### PR DESCRIPTION
before (i think the issue got intruduced by 3eb3aa2)
<img width="494" height="86" alt="image" src="https://github.com/user-attachments/assets/86300134-d6e9-497a-9588-3133a1299eb3" />


after
<img width="494" height="86" alt="image" src="https://github.com/user-attachments/assets/57061993-b4ed-4ce8-94c7-9dd62b523f05" />
