### PR TITLE
Add fallback param to DefineParameter

### DIFF
--- a/LuaDefinitionMaker/BasicType.cs
+++ b/LuaDefinitionMaker/BasicType.cs
@@ -97,7 +97,9 @@ public class BasicType : LuaType
             foreach (var parameter in method.GetParameters())
             {
                 var pType = parameter.GetCustomAttribute<LuaCustomType>()?.Target ?? parameter.ParameterType;
-                var lua = Program.GetLuaType(pType, false);
+                bool isNullable = parameter.HasDefaultValue && parameter.DefaultValue == null ||
+                          Nullable.GetUnderlyingType(pType) != null;
+                var lua = Program.GetLuaType(pType, false, isNullable);
                 sb.Append($"---@param {parameter.Name} {lua}");
 
                 var desc = doc.GetParameterDescription(parameter.Name!);

--- a/LuaDefinitionMaker/Program.cs
+++ b/LuaDefinitionMaker/Program.cs
@@ -93,7 +93,7 @@ internal class Program
             File.WriteAllText($"{out_dir}/{name}.lua", content.ToString().Trim());
     }
 
-    public static string GetLuaType(Type type, bool enumToNumber = true)
+    public static string GetLuaType(Type type, bool enumToNumber = true, bool nullable = false)
     {
         string? name = type.FullName switch
         {
@@ -116,10 +116,11 @@ internal class Program
                 name = (t.BaseType.IsEnum && enumToNumber) ? "number" : t.Name;
         }
 
-        if (name is not null) return name;
+        if (name is not null) 
+            return nullable ? $"{name}?" : name;
 
         Warn($"Failed to find matching lua type for '{type}'.");
-        return type.Name;
+        return nullable ? $"{type.Name}?" : type.Name;
     }
 
     private static XmlDocument? loadXml(string file)

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -436,7 +436,7 @@ public partial class StoryboardElementSettings : CompositeDrawable
                                 drawables.Add(new PointSettingsTextBox
                                 {
                                     Text = parameter.Title,
-                                    DefaultText = item.GetParameter(parameter.Key, ""),
+                                    DefaultText = item.GetParameter(parameter.Key, parameter.GetDefaultFallback<string>()),
                                     OnTextChanged = t =>
                                     {
                                         item.Parameters[parameter.Key] = t.Text;
@@ -449,7 +449,7 @@ public partial class StoryboardElementSettings : CompositeDrawable
                                 drawables.Add(new PointSettingsTextBox
                                 {
                                     Text = parameter.Title,
-                                    DefaultText = item.GetParameter(parameter.Key, 0).ToString(),
+                                    DefaultText = item.GetParameter(parameter.Key, parameter.GetDefaultFallback<int>()).ToString(),
                                     OnTextChanged = box =>
                                     {
                                         if (box.Text.TryParseIntInvariant(out var result))
@@ -466,7 +466,7 @@ public partial class StoryboardElementSettings : CompositeDrawable
                                 drawables.Add(new PointSettingsTextBox
                                 {
                                     Text = parameter.Title,
-                                    DefaultText = item.GetParameter(parameter.Key, 0f).ToStringInvariant(),
+                                    DefaultText = item.GetParameter(parameter.Key, parameter.GetDefaultFallback<float>()).ToStringInvariant(),
                                     OnTextChanged = box =>
                                     {
                                         if (box.Text.TryParseFloatInvariant(out var result))

--- a/fluXis/Scripting/ScriptRunner.cs
+++ b/fluXis/Scripting/ScriptRunner.cs
@@ -18,7 +18,7 @@ public class ScriptRunner
     [CanBeNull]
     protected MapInfo Map { get; set; }
 
-    public Action<string, string, string> DefineParameter;
+    public Action<string, string, string, object> DefineParameter;
     protected Lua Lua { get; }
 
     protected ScriptRunner()
@@ -73,8 +73,10 @@ public class ScriptRunner
         return point.BPM;
     }
 
+    #nullable enable
     [LuaGlobal(Name = "DefineParameter")]
-    private void defineParameter(string key, string title, [LuaCustomType(typeof(ParameterDefinitionType))] string type) => DefineParameter?.Invoke(key, title, type);
+    private void defineParameter(string key, string title, [LuaCustomType(typeof(ParameterDefinitionType))] string type, object? fallback = default) => DefineParameter?.Invoke(key, title, type, fallback);
+    #nullable disable
 
     [LuaGlobal]
     private void print(string text) => Logger.Add($"[Script] {text}");

--- a/scripting/library/shared.lua
+++ b/scripting/library/shared.lua
@@ -14,7 +14,8 @@ function BPMAtTime(time) end
 ---@param key string
 ---@param title string
 ---@param type ParameterDefinitionType
-function DefineParameter(key, title, type) end
+---@param fallback any?
+function DefineParameter(key, title, type, fallback) end
 
 ---@param text string
 function print(text) end


### PR DESCRIPTION
creating the scripts fills all the fields with the default params making it much less error prone.

---

The PR below has changes to Lua Definitions that doesn't include nullable types:
- #204 
(so I remember)