### PR TITLE
consider various edge cases when converting osu mania maps

### DIFF
--- a/fluXis.Import.osu/Map/Components/OsuTimingPoint.cs
+++ b/fluXis.Import.osu/Map/Components/OsuTimingPoint.cs
@@ -13,22 +13,29 @@ public class OsuTimingPoint
 
     public bool IsScrollVelocity => Inherited == 0 || BeatLength < 0;
 
+    // some gimmick maps might have absurdly high bpm. fluxis doesn't like that, so let's cap it at a reasonable 10 millions bpm.
+    public float BPM => Math.Clamp(60000 / BeatLength, 1, 10000000);
+
+    public double ScrollMultiplier => Math.Clamp(-100 / (double)BeatLength, 0.1f, 10);
+
     public TimingPoint ToTimingPointInfo()
     {
         return new TimingPoint
         {
             Time = Time,
-            BPM = 60000 / BeatLength,
+            BPM = BPM,
             Signature = Meter
         };
     }
 
-    public ScrollVelocity ToScrollVelocityInfo()
+    public ScrollVelocity ToScrollVelocityInfo(float dominantBpm, float bpm)
     {
+        float bpmMultiplier = bpm / dominantBpm;
+
         return new ScrollVelocity
         {
             Time = Time,
-            Multiplier = Math.Clamp(-100 / (double)BeatLength, 0.1f, 10)
+            Multiplier = ScrollMultiplier * bpmMultiplier
         };
     }
 }

--- a/fluXis.Import.osu/Map/OsuMap.cs
+++ b/fluXis.Import.osu/Map/OsuMap.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using fluXis.Import.osu.Map.Components;
@@ -90,18 +91,69 @@ public class OsuMap
             ScrollVelocities = new List<ScrollVelocity>(),
             InitialKeyCount = (int)CircleSize,
             AccuracyDifficulty = OverallDifficulty,
-            HealthDifficulty = HealthDrainRate
+            HealthDifficulty = Math.Max(HealthDrainRate, 1)
         };
 
-        foreach (var timingPoint in TimingPoints)
+        // in the context of osu mania, knowing the dominant bpm is useful because the scroll speed is dependant of the bpm.
+        // for example, if the dominant bpm of a map is 100, and the bpm at some part of the map is 200, the scroll speed will be two times faster at that part.
+        // to keep a constant scroll speed and compensate the bpm change, the map would need to have an effect point with a 0.5x multiplier.
+        // however, some sv maps also use this mechanic to simulate scroll multipliers above 10x or below 0.01x.
+        // in any case, the bpm doesn't impact the scroll speed in fluxis, so we need to explicitly add/adjust scroll velocities at bpm changes
+        // during the conversion to make the map look the same as in the original game.
+        float dominantBpm = getDominantBPM();
+        float currentBpm = dominantBpm;
+
+        for (int i = 0; i < TimingPoints.Count; ++i)
         {
-            if (timingPoint.IsScrollVelocity)
-                mapInfo.ScrollVelocities.Add(timingPoint.ToScrollVelocityInfo());
+            OsuTimingPoint currentPoint = TimingPoints[i];
+
+            // check if we have both a bpm point and effect point at the same time
+            if (i != TimingPoints.Count - 1 && TimingPoints[i + 1].IsScrollVelocity != currentPoint.IsScrollVelocity && TimingPoints[i + 1].Time == currentPoint.Time)
+            {
+                // identify which point is sv and which point is bpm
+                (OsuTimingPoint svPoint, OsuTimingPoint bpmPoint) = currentPoint.IsScrollVelocity
+                    ? (currentPoint, TimingPoints[i + 1])
+                    : (TimingPoints[i + 1], currentPoint);
+
+                mapInfo.TimingPoints.Add(bpmPoint.ToTimingPointInfo());
+                currentBpm = bpmPoint.BPM;
+                mapInfo.ScrollVelocities.Add(svPoint.ToScrollVelocityInfo(dominantBpm, currentBpm));
+
+                i++; // skip next point because we already handled it
+            }
+            // only one point at the current time
             else
-                mapInfo.TimingPoints.Add(timingPoint.ToTimingPointInfo());
+            {
+                if (currentPoint.IsScrollVelocity)
+                {
+                    mapInfo.ScrollVelocities.Add(currentPoint.ToScrollVelocityInfo(dominantBpm, currentBpm));
+                }
+                else
+                {
+                    mapInfo.TimingPoints.Add(currentPoint.ToTimingPointInfo());
+                    currentBpm = currentPoint.BPM;
+
+                    // in osu mania, a bpm timing point alone (i.e. no simultaneous sv/effect point) will change the scroll speed
+                    // (this matches osu!stable, osu!lazer behaves a bit differently, but most maps expect stable's behavior)
+                    double multiplier = currentBpm / dominantBpm; //this purposely doesn't take into account the multiplier of the previous effect point
+
+                    // some gimmick maps might add A LOT of timing points really close to each others to add lots of barlines.
+                    // in cases these timing points have the same bpm, we don't want to add the same scroll velocities lots of times
+                    // (right now this is commented because this makes the barlines look different on some maps and i don't understand why)
+                    // if (mapInfo.ScrollVelocities.Count >= 1 && mapInfo.ScrollVelocities.Last().Multiplier == multiplier) continue;
+
+                    mapInfo.ScrollVelocities.Add(new ScrollVelocity
+                    {
+                        Time = currentPoint.Time,
+                        Multiplier = multiplier
+                    });
+                }
+            }
         }
 
-        mapInfo.HitObjects.AddRange(HitObjects.Select(h => h.ToHitObjectInfo(this)));
+        // some gimmick maps might contain LNs with a start time equal to Nan to create fake notes (these are known as p notes)
+        // these are problematic when trying to play the map after converting, so ignore them for now
+        mapInfo.HitObjects.AddRange(HitObjects.FindAll(h => !float.IsNaN(h.StartTime)).Select(h => h.ToHitObjectInfo(this)));
 
         foreach (var osuEvent in Events)
         {
@@ -120,5 +172,52 @@ public class OsuMap
         }
 
         return mapInfo;
+    }
+
+    private float getDuration()
+    {
+        float duration = 0;
+
+        foreach (var osuHitObject in HitObjects)
+        {
+            float objectEnd = osuHitObject.Type == OsuHitObjectType.Hold ? osuHitObject.EndTime : osuHitObject.StartTime;
+            if (objectEnd > duration) duration = objectEnd;
+        }
+
+        return duration;
+    }
+
+    private float getDominantBPM()
+    {
+        float mapDuration = getDuration();
+
+        Dictionary<float, float> bpmDurations = new();
+        var bpmPoints = TimingPoints.FindAll(p => !p.IsScrollVelocity);
+
+        for (int i = 0; i < bpmPoints.Count; ++i)
+        {
+            OsuTimingPoint bpmPoint = bpmPoints[i];
+            float bpm = bpmPoint.BPM;
+            float duration = (i == bpmPoints.Count - 1 || bpmPoints[i + 1].Time > mapDuration)
+                ? mapDuration - bpmPoint.Time
+                : bpmPoints[i + 1].Time - bpmPoint.Time;
+
+            if (!bpmDurations.TryAdd(bpm, duration))
+                bpmDurations[bpm] += duration;
+        }
+
+        float dominantBPM = 1;
+        float highestDuration = 0;
+
+        foreach (var bpmDuration in bpmDurations)
+        {
+            if (bpmDuration.Value > highestDuration)
+            {
+                dominantBPM = bpmDuration.Key;
+                highestDuration = bpmDuration.Value;
+            }
+        }
+
+        return dominantBPM;
     }
 }


### PR DESCRIPTION
this pr does the following
- some maps might have an health drain value of 0, but when importing the map in fluxis, it will be set to 8. i made sure it is set to 1 instead in such cases
- in osu mania, bpm changes actually change the scroll speed. while we can barely see the difference on "regular" maps, some sv maps abuse this to get huge scroll multipliers. this pr makes it so on each bpm changes, a scroll velocity is added to match osu!stable's behaviour, and the current bpm is also taken into account for each effect points ([useful reference](https://github.com/Eve-ning/SV-Crash-Course-LaTeX/blob/master/builds/11082018.pdf))
- explicitly ignore p notes (which, in most cases, are creating using LNs with a start time of NaN and an n time of where the mapper want to place the p notes). there exists [more complex types of pnotes](https://niv.gay/osumania-research-lab/P-Note.html), but i haven't done anything to handle these.

i tried to explain things as clearly as possible in comments to make sure anyone who doesn't know about these edge cases can understand why i did things this way, but this might feel over-commented idk

i obviously haven't tested every sv map in existence, but here are some of the most cursed maps i know converted using these changes

[Hito Mania](https://osu.ppy.sh/beatmapsets/2118981#mania/4450978) (doesn't start on the current version of the game because of p notes and cursed bpm)

https://github.com/user-attachments/assets/8423f61b-982b-46b7-b4da-641ea4386ee1


[Digibuprofen](https://osu.ppy.sh/beatmapsets/2062256#mania/4311995) (doesn't start on the current version of the game due to insanely high bpm) (yes this is what 1:52 IGT is supposed to look like)

https://github.com/user-attachments/assets/f9055504-0798-472b-97e3-95913c14ca39


[dont say "i can sample that" for 24 hours challenge](https://osu.ppy.sh/beatmapsets/2025428#mania/4219687) (on the current version of the game, the bpm-only effects at 1:02 IGT don't do anything)

https://github.com/user-attachments/assets/eefcbdbb-f0d7-4d79-9a97-c080b4f21d58


[stresstest](https://osu.ppy.sh/beatmapsets/2264648#mania/4821295) (on the current version of the game most of the teleport effects don't work, some parts are really hard to play due to low scroll speed)

https://github.com/user-attachments/assets/3f1e2268-32e3-4489-b060-138b9ebde750


closes #72 (hopefully)