### PR TITLE
Fix DIscord RPC Crashing Game

### DIFF
--- a/fluXis.Desktop/Integration/DiscordActivity.cs
+++ b/fluXis.Desktop/Integration/DiscordActivity.cs
@@ -86,9 +86,9 @@ public class DiscordActivity
             Details = truncateWithLog(rpc.Details, 128, "Details"),
             Assets = new Assets
             {
-                LargeImageKey = truncateWithLog(rpc.LargeImage, 32, "LargeImageKey"),
+                LargeImageKey = truncateWithLog(rpc.LargeImage, 300, "LargeImageKey"),
                 LargeImageText = truncateWithLog(rpc.LargeImageText, 128, "LargeImageText"),
-                SmallImageKey = truncateWithLog(rpc.SmallImage, 32, "SmallImageKey"),
+                SmallImageKey = truncateWithLog(rpc.SmallImage, 300, "SmallImageKey"),
                 SmallImageText = truncateWithLog(rpc.SmallImageText, 128, "SmallImageText")
             },
             Timestamps = new Timestamps()

--- a/fluXis.Desktop/Integration/DiscordActivity.cs
+++ b/fluXis.Desktop/Integration/DiscordActivity.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Linq;
+using System.Text;
 using DiscordRPC;
 using DiscordRPC.Message;
 using fluXis.Integration;
 using fluXis.Online.Fluxel;
 using fluXis.Utils;
+using Humanizer;
 using Newtonsoft.Json;
 using osu.Framework.Logging;
 using EventType = DiscordRPC.EventType;
@@ -55,18 +57,39 @@ public class DiscordActivity
         game.JoinMultiplayerRoom(secret.ID, secret.Password);
     }
 
+    private static string truncateWithLog(string value, int maxBytes, string fieldName = null)
+    {
+        string field = !string.IsNullOrEmpty(fieldName) ? $"{fieldName}" : "";
+
+        if (string.IsNullOrEmpty(value))
+        {
+            Logger.Log($"Discord RPC {field} is empty or null.", LoggingTarget.Network, LogLevel.Verbose);
+            return value ?? "";
+        }
+        
+        var bytes = Encoding.UTF8.GetByteCount(value);
+        
+        if (bytes > maxBytes)
+        {
+            Logger.Log($"Discord RPC {field} exceeded {maxBytes} bytes (was {bytes} bytes), truncating...", LoggingTarget.Network, LogLevel.Verbose);
+            return StringUtils.TruncateBytes(value, maxBytes);
+        }
+        
+        return value;
+    }
+
     private static RichPresence build(DiscordRichPresence rpc)
     {
         var discord = new RichPresence
         {
-            State = rpc.State[..Math.Min(rpc.State.Length, 128)],
-            Details = rpc.Details[..Math.Min(rpc.Details.Length, 128)],
+            State = truncateWithLog(rpc.State, 128, "State"),
+            Details = truncateWithLog(rpc.Details, 128, "Details"),
             Assets = new Assets
             {
-                LargeImageKey = rpc.LargeImage,
-                LargeImageText = rpc.LargeImageText,
-                SmallImageKey = rpc.SmallImage,
-                SmallImageText = rpc.SmallImageText
+                LargeImageKey = truncateWithLog(rpc.LargeImage, 32, "LargeImageKey"),
+                LargeImageText = truncateWithLog(rpc.LargeImageText, 128, "LargeImageText"),
+                SmallImageKey = truncateWithLog(rpc.SmallImage, 32, "SmallImageKey"),
+                SmallImageText = truncateWithLog(rpc.SmallImageText, 128, "SmallImageText")
             },
             Timestamps = new Timestamps()
         };

--- a/fluXis/Screens/Gameplay/GameplayScreen.cs
+++ b/fluXis/Screens/Gameplay/GameplayScreen.cs
@@ -89,15 +89,16 @@ public partial class GameplayScreen : FluXisScreen, IKeyBindingHandler<FluXisGlo
         get
         {
             var title = "";
+            bool usingOriginalMetadata = Game?.UsingOriginalMetadata ?? false;
 
-            if (Game.UsingOriginalMetadata || string.IsNullOrWhiteSpace(Map.Metadata.ArtistRomanized))
+            if (usingOriginalMetadata || string.IsNullOrWhiteSpace(Map.Metadata.ArtistRomanized))
                 title += Map.Metadata.Artist;
             else
                 title += Map.Metadata.ArtistRomanized;
 
             title += " - ";
 
-            if (Game.UsingOriginalMetadata || string.IsNullOrWhiteSpace(Map.Metadata.TitleRomanized))
+            if (usingOriginalMetadata || string.IsNullOrWhiteSpace(Map.Metadata.TitleRomanized))
                 title += Map.Metadata.Title;
             else
                 title += Map.Metadata.TitleRomanized;

--- a/fluXis/Screens/Gameplay/GameplayScreen.cs
+++ b/fluXis/Screens/Gameplay/GameplayScreen.cs
@@ -100,7 +100,7 @@ public partial class GameplayScreen : FluXisScreen, IKeyBindingHandler<FluXisGlo
 
             title += " - ";
 
-            if (usingOriginalMetadata || string.IsNullOrWhiteSpace(Map.Metadata.TitleRomanized))
+            if (Game.UsingOriginalMetadata || string.IsNullOrWhiteSpace(Map.Metadata.TitleRomanized))
                 title += Map.Metadata.Title;
             else
                 title += Map.Metadata.TitleRomanized;

--- a/fluXis/Utils/StringUtils.cs
+++ b/fluXis/Utils/StringUtils.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Text;
 
 namespace fluXis.Utils;
 
@@ -40,6 +41,24 @@ public static class StringUtils
         }
 
         return $"{adjust:0.0}{size_suffixes[m]}";
+    }
+
+    public static string TruncateBytes(string value, int maxBytes)
+    {
+        if (string.IsNullOrEmpty(value))
+            return value ?? "";
+        
+        var encoding = Encoding.UTF8;
+        if (encoding.GetByteCount(value) <= maxBytes)
+            return value;
+        
+        var bytes = encoding.GetBytes(value);
+        var truncated = encoding.GetString(bytes, 0, Math.Min(bytes.Length, maxBytes));
+        
+        while (encoding.GetByteCount(truncated) > maxBytes && truncated.Length > 0)
+            truncated = truncated[..^1];
+        
+        return truncated;
     }
 
     public static string CensorEmail(string mail)


### PR DESCRIPTION
Discord RPC fields should be truncated by bytes not characters, even though the official documentation says between *characters* it's likely ASCII characters since they are 1 byte, other than that it's a max of bytes not characters.

An actual case of a map having this bug:
https://dev.flux.moe/set/1599#2997

## Changes
- fix discord rpc truncation
- added truncation for other fields
- fix gameplay not loading in tests, caused by Game.UsingOriginalMetadata being null

The Docs:
- https://discord.com/developers/docs/social-sdk/classdiscordpp_1_1Activity.html
- https://discord.com/developers/docs/social-sdk/classdiscordpp_1_1ActivityAssets.html