### PR TITLE
Resize Header Background to Correct Size

### DIFF
--- a/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
+++ b/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
@@ -94,7 +94,7 @@ public partial class SelectMapInfoHeader : CompositeDrawable
                         Masking = true,
                         Children = new Drawable[]
                         {
-                            backgrounds = new SpriteStack<LoadWrapper<MapBackground>>(),
+                            backgrounds = new SpriteStack<LoadWrapper<MapBackground>> { AutoFill = false },
                             new SectionedGradient
                             {
                                 RelativeSizeAxes = Axes.Both,
@@ -293,8 +293,6 @@ public partial class SelectMapInfoHeader : CompositeDrawable
             LoadContent = () => new MapBackground(map)
             {
                 RelativeSizeAxes = Axes.Both,
-                FillMode = FillMode.Fit,
-                FillAspectRatio = 1f,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre
             },

--- a/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
+++ b/fluXis/Screens/Select/Info/Header/SelectMapInfoHeader.cs
@@ -293,6 +293,8 @@ public partial class SelectMapInfoHeader : CompositeDrawable
             LoadContent = () => new MapBackground(map)
             {
                 RelativeSizeAxes = Axes.Both,
+                FillMode = FillMode.Fit,
+                FillAspectRatio = 1f,
                 Anchor = Anchor.Centre,
                 Origin = Anchor.Centre
             },


### PR DESCRIPTION
### How it was prior to #192
<img width="939" height="420" alt="{64EF8471-62E8-47B1-A91D-1E0637BF5232}" src="https://github.com/user-attachments/assets/7cb3721b-a744-41db-90fc-2f2a2c33beab" />

### How it is after #192
<img width="943" height="427" alt="{65D52E0A-AAAF-453A-8B0D-CE7AEE7F473D}" src="https://github.com/user-attachments/assets/22905076-e926-4760-881f-4d102e228371" />


Now it's sized correctly instead of it being way zoomed in.