### PR TITLE
Fix Editor Seemingly Crashing at Random

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Lines/EditorTimingLines.cs
@@ -154,6 +154,15 @@ public abstract partial class EditorTimingLines<T> : Container<T>
         }
 
         protected override void Update() => Position = Parent.GetPosition(Time);
-        public int CompareTo(Line other) => Time.CompareTo(other.Time);
+        
+        public int CompareTo(Line other)
+        {
+            int cmp = Time.CompareTo(other.Time);
+            if (cmp != 0)
+                return cmp;
+            
+            return this.GetHashCode()
+                    .CompareTo(other.GetHashCode());
+        }
     }
 }


### PR DESCRIPTION
when the comparison returns zero (equal to each other) it fails to sort correctly and you get an exception like this when it comes to removing the line:

```
2026-01-18 00:23:14 [error]: An unhandled error has occurred.
2026-01-18 00:23:14 [error]: System.InvalidOperationException: A non-matching Drawable was returned. Please ensure fluXis.Screens.Edit.Tabs.Charting.Playfield.ChartingTimingLines's Compare override implements a stable sort algorithm.
```

From my tests this crash often happens when cloning a timing point and immediately scrolling. This of course can happen due to various other reasons but I've found this to be the most reproduceable way to do so.