### PR TITLE
Allow Fading any Layer in Layer Fade for any Playfield/Subfield

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Design/Points/Entries/LayerFadeEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/Entries/LayerFadeEntry.cs
@@ -33,7 +33,7 @@ public partial class LayerFadeEntry : PointListEntry
     {
         var str = $"{fade.Layer.ToString()} {(fade.Alpha * 100).ToStringInvariant()}% {(int)fade.Duration}ms";
 
-        if (fade.Layer == LayerFadeEvent.FadeLayer.Playfield)
+        if (fade.Layer != LayerFadeEvent.FadeLayer.HUD)
             str += $" P{fade.PlayfieldIndex}S{fade.PlayfieldSubIndex}";
 
         return new FluXisSpriteText

--- a/fluXis/Screens/Edit/Tabs/Design/Points/Entries/LayerFadeEntry.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/Points/Entries/LayerFadeEntry.cs
@@ -45,7 +45,7 @@ public partial class LayerFadeEntry : PointListEntry
 
     protected override IEnumerable<Drawable> CreateSettings()
     {
-        var layerPlayfield = new BindableBool(fade.Layer == LayerFadeEvent.FadeLayer.Playfield);
+        var isNotHUD = new BindableBool(fade.Layer != LayerFadeEvent.FadeLayer.HUD);
 
         return base.CreateSettings().Concat(new Drawable[]
         {
@@ -73,7 +73,7 @@ public partial class LayerFadeEntry : PointListEntry
                 OnValueChanged = value =>
                 {
                     fade.Layer = value;
-                    layerPlayfield.Value = value == LayerFadeEvent.FadeLayer.Playfield;
+                    isNotHUD.Value = value != LayerFadeEvent.FadeLayer.HUD;
                     Map.Update(fade);
                 }
             },
@@ -85,7 +85,7 @@ public partial class LayerFadeEntry : PointListEntry
                 Min = 0,
                 Max = Map.MapInfo.IsDual ? 2 : 0,
                 Step = 1,
-                Enabled = layerPlayfield,
+                Enabled = isNotHUD,
                 HideWhenDisabled = true,
                 OnValueChanged = value =>
                 {
@@ -101,7 +101,7 @@ public partial class LayerFadeEntry : PointListEntry
                 Min = 0,
                 Max = Map.MapInfo.ExtraPlayfields + 1,
                 Step = 1,
-                Enabled = layerPlayfield,
+                Enabled = isNotHUD,
                 HideWhenDisabled = true,
                 OnValueChanged = value =>
                 {


### PR DESCRIPTION
People are already going around this by changing from playfield to another layer that you can't change the playfield index of and this works because the playfield index fields in the event stay the same.

So it should be logical that you can normally change the playfield index in-game without using roundabout methods, Especially if a pure map already does this to bypass this limitation.