### PR TITLE
Add more blending modes

### DIFF
--- a/LuaDefinitionMaker/Program.cs
+++ b/LuaDefinitionMaker/Program.cs
@@ -58,6 +58,7 @@ internal class Program
                 Anchor.BottomLeft, Anchor.BottomCentre, Anchor.BottomRight
             }
         });
+        typeList.Add(new EnumType<DefaultBlendingParameters>(true, ctorName: "BlendMode", enumName: "BlendMode"));
 
         var eventTypes = LuaMap.GetMapEventTypes();
         eventTypes.Remove(typeof(ScriptEvent));
@@ -134,7 +135,7 @@ internal class Program
                 name = (t.BaseType.IsEnum && enumToNumber) ? "number" : t.Name;
         }
 
-        if (name is not null) 
+        if (name is not null)
             return nullable ? $"{name}?" : name;
 
         string fallbackType = getLuaTypeName(fallback) ?? fallback?.Name ?? type.Name;

--- a/fluXis.Import.osu/Storyboards/OsuStoryboardParser.cs
+++ b/fluXis.Import.osu/Storyboards/OsuStoryboardParser.cs
@@ -399,6 +399,7 @@ public class OsuStoryboardParser
                             {
                                 case "A":
                                     currentElement.Blending = true;
+                                    currentElement.BlendingMode = DefaultBlendingParameters.Add;
                                     break;
                             }
 

--- a/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/PointSettingsDropdown.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Points/Settings/PointSettingsDropdown.cs
@@ -22,6 +22,9 @@ public partial class PointSettingsDropdown<T> : PointSettingsBase, IHasTooltip
 
     public Bindable<T> Bindable { get; set; }
 
+    public Bindable<bool> Enabled { get; init; } = new(true);
+    public bool HideWhenDisabled { get; init; } = false;
+
     [BackgroundDependencyLoader]
     private void load()
     {
@@ -59,6 +62,9 @@ public partial class PointSettingsDropdown<T> : PointSettingsBase, IHasTooltip
         base.LoadComplete();
 
         Bindable.BindValueChanged(valueChanged);
+
+        Enabled.BindValueChanged(e => this.FadeTo(e.NewValue ? 1f : HideWhenDisabled ? 0 : .4f, 200), true);
+        FinishTransforms();
     }
 
     protected override void Dispose(bool isDisposing)

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -22,6 +22,7 @@ using fluXis.Utils;
 using fluXis.Utils.Attributes;
 using JetBrains.Annotations;
 using osu.Framework.Allocation;
+using osu.Framework.Bindables;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
@@ -133,6 +134,8 @@ public partial class StoryboardElementSettings : CompositeDrawable
 
             case 1:
                 var item = collection.First();
+                var blendingEnabled = new BindableBool(item.Blending);
+
                 var drawables = new List<Drawable>
                 {
                     new FluXisSpriteText
@@ -219,6 +222,30 @@ public partial class StoryboardElementSettings : CompositeDrawable
                         OnValueChanged = o =>
                         {
                             item.Origin = o;
+                            map.Update(item);
+                        }
+                    },
+                    new PointSettingsToggle
+                    {
+                        Text = "Blend",
+                        CurrentValue = item.Blending,
+                        OnStateChanged = enabled =>
+                        {
+                            blendingEnabled.Value = enabled;
+                            item.Blending = enabled;
+                            map.Update(item);
+                        }
+                    },
+                    new PointSettingsDropdown<DefaultBlendingParameters>
+                    {
+                        Text = "Blend Mode",
+                        CurrentValue = item.BlendingMode,
+                        Items = Enum.GetValues<DefaultBlendingParameters>().ToList(),
+                        Enabled = blendingEnabled,
+                        HideWhenDisabled = true,
+                        OnValueChanged = mode =>
+                        {
+                            item.BlendingMode = mode;
                             map.Update(item);
                         }
                     }

--- a/fluXis/Scripting/Models/Storyboarding/LuaStoryboardElement.cs
+++ b/fluXis/Scripting/Models/Storyboarding/LuaStoryboardElement.cs
@@ -42,6 +42,9 @@ public class LuaStoryboardElement : ILuaModel
     [LuaMember(Name = "blend")]
     public bool Blending { get; set; }
 
+    [LuaMember(Name = "blendMode")]
+    public DefaultBlendingParameters BlendingMode { get; set; } = DefaultBlendingParameters.Add;
+
     [LuaMember(Name = "width")]
     public float Width { get; set; }
 
@@ -117,6 +120,7 @@ public class LuaStoryboardElement : ILuaModel
         StartX = element.StartX,
         StartY = element.StartY,
         Blending = element.Blending,
+        BlendingMode = element.BlendingMode,
         Width = element.Width,
         Height = element.Height,
         Color = element.Color,

--- a/fluXis/Storyboards/Drawables/DrawableStoryboardElement.cs
+++ b/fluXis/Storyboards/Drawables/DrawableStoryboardElement.cs
@@ -30,8 +30,8 @@ public partial class DrawableStoryboardElement : CompositeDrawable
         Colour = Colour4.FromRGBA(Element.Color);
         AlwaysPresent = true;
 
-        if (Element.Blending)
-            Blending = BlendingParameters.Additive;
+        Blending = Element.Blending ?
+            BlendingParameters.GetDefaultParameters(Element.BlendingMode) : BlendingParameters.Mixture;
 
         foreach (var animation in Element.Animations)
         {

--- a/fluXis/Storyboards/StoryboardElement.cs
+++ b/fluXis/Storyboards/StoryboardElement.cs
@@ -62,6 +62,9 @@ public class StoryboardElement : ITimedObject
     [JsonProperty("blend")]
     public bool Blending { get; set; }
 
+    [JsonProperty("blend-mode")]
+    public DefaultBlendingParameters BlendingMode { get; set; } = DefaultBlendingParameters.Add;
+
     [JsonProperty("width")]
     public float Width { get; set; }
 

--- a/scripting/library/enums.lua
+++ b/scripting/library/enums.lua
@@ -59,6 +59,22 @@ function Easing(input) end
 ---@nodiscard
 function Anchor(input) end
 
+---@alias BlendMode string
+---| "None"
+---| "Inherit"
+---| "Mix"
+---| "Difference"
+---| "Add"
+---| "Subtract"
+---| "Screen"
+---| "Multiply"
+---| "Premultiplied"
+
+---@param input BlendMode
+---@return number
+---@nodiscard
+function BlendMode(input) end
+
 ---@alias EventType string
 ---| "BeatPulse"
 ---| "ColorFade"

--- a/scripting/library/storyboard.lua
+++ b/scripting/library/storyboard.lua
@@ -56,6 +56,7 @@ metadata = {}
 ---@field y number
 ---@field z number
 ---@field blend boolean
+---@field blendMode number
 ---@field width number
 ---@field height number
 ---@field color number


### PR DESCRIPTION
I hope I didn't explode the framework.

## Changes
- Added selectable blend modes instead of blend being only a toggle for additive blending
- Removed artifacts from webp
    + the reason for this being is that when testing the blend modes on a webp image the image was VERY blocky.
