### PR TITLE
Fix Sidebar Still Being Collapsed When Clicking on Tags

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Shared/Points/List/PointsList.cs
+++ b/fluXis/Screens/Edit/Tabs/Shared/Points/List/PointsList.cs
@@ -383,7 +383,6 @@ public abstract partial class PointsList : Container
 
     public void ShowPoint(ITimedObject obj)
     {
-        RequestClose?.Invoke();
         var entry = flow.FirstOrDefault(e => e.Object == obj);
         entry?.OpenSettings();
     }


### PR DESCRIPTION
When you click on a tag it looks like this:

<img width="605" height="784" alt="image" src="https://github.com/user-attachments/assets/a2731c33-5b42-4b5b-9714-041c75040aa7" />

Now it opens normally:

<img width="447" height="685" alt="{3527F770-524F-44B3-B995-06313934B0AA}" src="https://github.com/user-attachments/assets/08316174-5542-42cc-b9e9-c0773cecc5aa" />
