### PR TITLE
Properly reset parallax container when disabling

### DIFF
--- a/fluXis/Graphics/Containers/ParallaxContainer.cs
+++ b/fluXis/Graphics/Containers/ParallaxContainer.cs
@@ -75,6 +75,9 @@ public partial class ParallaxContainer : Container
 
     private void onChange(ValueChangedEvent<bool> enabled)
     {
-        this.MoveTo(Vector2.Zero, 400, Easing.OutQuint);
+        if (enabled.NewValue) return;
+
+        content.MoveTo(Vector2.Zero, 400, Easing.OutQuint);
+        content.ScaleTo(Vector2.One, 400, Easing.OutQuint);
     }
 }


### PR DESCRIPTION
Fixes `ParallaxContainer` not properly resetting the Position and Scale of its content