### PR TITLE
 display correct user on result screen after watching someone else's replay

### DIFF
--- a/fluXis/Screens/Gameplay/GameplayScreen.cs
+++ b/fluXis/Screens/Gameplay/GameplayScreen.cs
@@ -539,7 +539,7 @@ public partial class GameplayScreen : FluXisScreen, IKeyBindingHandler<FluXisGlo
 
         Task.Run(() =>
         {
-            var screen = new SoloResults(RealmMap, score, api.User.Value ?? APIUser.Default);
+            var screen = new SoloResults(RealmMap, score, PlayfieldManager.Players[0].ScoreProcessor.Player ?? APIUser.Default);
             screen.OnRestart = OnRestart;
             if (bestScore != null) screen.ComparisonScore = bestScore.ToScoreInfo();
 

--- a/fluXis/Screens/Result/Header/ResultsPlayer.cs
+++ b/fluXis/Screens/Result/Header/ResultsPlayer.cs
@@ -108,7 +108,7 @@ public partial class ResultsPlayer : CompositeDrawable
 
     protected override bool OnClick(ClickEvent e)
     {
-        overlay?.ShowUser(user.ID);
+        if (user.ID > 0) overlay?.ShowUser(user.ID);
         return true;
     }
 }


### PR DESCRIPTION
currently, after watching a replay, the result screen will display the user that is currently logged in, even if the replay comes from another player

before (this replay actually comes from billiack, but my name is displayed on the top right):

<img width="1912" height="1004" alt="image" src="https://github.com/user-attachments/assets/21d227cd-cb94-48d2-9d30-5fa548023691" />

after:

<img width="1912" height="1004" alt="Screenshot From 2026-02-21 14-57-20" src="https://github.com/user-attachments/assets/d311a238-c04a-412e-82f0-920e90748525" />
