### PR TITLE
fix importing maps containing directories on linux

### DIFF
--- a/fluXis/Import/FluXisImport.cs
+++ b/fluXis/Import/FluXisImport.cs
@@ -170,7 +170,7 @@ public class FluXisImport : MapImporter
 
         foreach (var entry in archive.Entries)
         {
-            var filePath = fullPath + entry.FullName;
+            var filePath = fullPath + entry.FullName.Replace('\\', Path.DirectorySeparatorChar);
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
             entry.ExtractToFile(filePath, true);
         }


### PR DESCRIPTION
if a map was originally created on windows, its paths in the archive will use backslashes '\\'

on linux, when importing such maps, the files get extracted like this (all of these are supposed to be in an "assets" directory):
<img width="277" height="117" alt="image" src="https://github.com/user-attachments/assets/016126fd-9eae-44e4-8a2c-d5c21efd31a9" />

with this pr, the files are extracted in their intended directory

this change makes the following maps import as intended on linux :
https://fluxis.flux.moe/set/1641#3051
https://fluxis.flux.moe/set/1614#3014
(possibly more, but these are the ones that made me notice this issue)

i don't have a computer running windows to check if this broke importing there, but because backslashes are replaced with Path.DirectorySeparatorChar (which should be \\ on windows) it shouldn't break anything