### PR TITLE
implement modding tab

### DIFF
--- a/fluXis/Graphics/Sprites/Icons/FontAwesome6.cs
+++ b/fluXis/Graphics/Sprites/Icons/FontAwesome6.cs
@@ -92,6 +92,7 @@ public class FontAwesome6
         public static IconUsage Minus => GetSolid(0xf068);
         public static IconUsage Music => GetSolid(0xf001);
         public static IconUsage Newspaper => GetSolid(0xf1ea);
+        public static IconUsage NoteSticky => GetSolid(0xf249);
         public static IconUsage ObjectGroup => GetSolid(0xf247);
         public static IconUsage PaintBrush => GetSolid(0xf1fc);
         public static IconUsage Palette => GetSolid(0xf53f);

--- a/fluXis/Online/API/Requests/MapSets/Favorite/MapSetModdingRequest.cs
+++ b/fluXis/Online/API/Requests/MapSets/Favorite/MapSetModdingRequest.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+using fluXis.Online.API.Models.Maps.Modding;
+using osu.Framework.IO.Network;
+
+namespace fluXis.Online.API.Requests.MapSets.Favorite;
+
+public class MapSetModdingRequest : APIRequest<List<APIModdingAction>>
+{
+    protected override string Path => $"/mapset/{id}/modding";
+    private long id { get; }
+
+    public MapSetModdingRequest(long id)
+    {
+        this.id = id;
+    }
+
+    protected override WebRequest CreateWebRequest(string url)
+    {
+        var req = base.CreateWebRequest(url);
+        return req;
+    }
+}

--- a/fluXis/Overlay/MapSet/MapSetOverlay.cs
+++ b/fluXis/Overlay/MapSet/MapSetOverlay.cs
@@ -203,6 +203,7 @@ public partial class MapSetOverlay : OverlayContainer, IKeyBindingHandler<FluXis
                                     {
                                         // new MapSetInfoTab(),
                                         new MapSetScoreTab(bindableMap),
+                                        new MapSetModdingTab(set),
                                         // new MapSetCommentsTab()
                                     }
                                 },

--- a/fluXis/Overlay/MapSet/Tabs/MapSetModdingTab.cs
+++ b/fluXis/Overlay/MapSet/Tabs/MapSetModdingTab.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using fluXis.Graphics.Sprites.Icons;
+using fluXis.Graphics.UserInterface.Tabs;
+using fluXis.Online.API.Models.Maps;
+using fluXis.Online.API.Models.Maps.Modding;
+using fluXis.Online.API.Requests.MapSets.Favorite;
+using fluXis.Online.Fluxel;
+using fluXis.Overlay.MapSet.UI.Modding;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+
+namespace fluXis.Overlay.MapSet.Tabs;
+
+public partial class MapSetModdingTab : TabContainer
+{
+    public override IconUsage Icon => FontAwesome6.Solid.PenRuler;
+    public override string Title => "Modding";
+
+    [Resolved]
+    private IAPIClient api { get; set; }
+
+    private readonly APIMapSet set;
+
+    public MapSetModdingTab(APIMapSet set)
+    {
+        this.set = set;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        var req = new MapSetModdingRequest(set.ID);
+        req.Success += res =>
+        {
+            InternalChild = new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Spacing = new Vector2(0, 16),
+                ChildrenEnumerable = res.Data.Select(createModdingAction)
+            };
+        };
+        api.PerformRequestAsync(req);
+    }
+
+    private Drawable createModdingAction(APIModdingAction action)
+    {
+        switch (action.Type)
+        {
+            case APIModdingActionType.Note:
+            case APIModdingActionType.Approve:
+            case APIModdingActionType.Deny:
+                return new ModdingActionComment(action);
+
+            default:
+                return new ModdingActionSimple(action);
+        }
+    }
+}

--- a/fluXis/Overlay/MapSet/UI/Modding/ModdingActionComment.cs
+++ b/fluXis/Overlay/MapSet/UI/Modding/ModdingActionComment.cs
@@ -1,0 +1,48 @@
+using fluXis.Online.API.Models.Maps.Modding;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+
+namespace fluXis.Overlay.MapSet.UI.Modding;
+
+public partial class ModdingActionComment : Container
+{
+    private readonly APIModdingAction action;
+
+    public ModdingActionComment(APIModdingAction action)
+    {
+        this.action = action;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        AutoSizeAxes = Axes.Y;
+        RelativeSizeAxes = Axes.X;
+
+        InternalChild = new GridContainer
+        {
+            RelativeSizeAxes = Axes.X,
+            AutoSizeAxes = Axes.Y,
+            ColumnDimensions = new[]
+            {
+                new Dimension(GridSizeMode.AutoSize),
+                new Dimension(GridSizeMode.Absolute, 8),
+                new Dimension(GridSizeMode.Distributed),
+            },
+            RowDimensions = new[]
+            {
+                new Dimension(GridSizeMode.AutoSize),
+            },
+            Content = new[]
+            {
+                new Drawable[]
+                {
+                    new ModdingActionCommentLeftSide(action.Type),
+                    null, //this represents the gap between the left side and the content box
+                    new ModdingActionCommentContent(action)
+                }
+            }
+        };
+    }
+}

--- a/fluXis/Overlay/MapSet/UI/Modding/ModdingActionCommentContent.cs
+++ b/fluXis/Overlay/MapSet/UI/Modding/ModdingActionCommentContent.cs
@@ -1,0 +1,99 @@
+using fluXis.Graphics.Containers;
+using fluXis.Graphics.Sprites.Text;
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Graphics.UserInterface.Text;
+using fluXis.Online.API.Models.Maps.Modding;
+using fluXis.Online.Drawables.Images;
+using fluXis.Utils;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osuTK;
+
+namespace fluXis.Overlay.MapSet.UI.Modding;
+
+public partial class ModdingActionCommentContent : Container
+{
+    private readonly APIModdingAction action;
+
+    public ModdingActionCommentContent(APIModdingAction action)
+    {
+        this.action = action;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        AutoSizeAxes = Axes.Y;
+        RelativeSizeAxes = Axes.X;
+        Masking = true;
+        CornerRadius = 8;
+        Children = new Drawable[]
+        {
+            new Box
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Theme.Background2,
+            },
+            new FillFlowContainer
+            {
+                Direction = FillDirection.Vertical,
+                RelativeSizeAxes = Axes.X,
+                AutoSizeAxes = Axes.Y,
+                Padding = new MarginPadding(16),
+                Spacing = new Vector2(0, 8),
+                Children = new Drawable[]
+                {
+                    new FillFlowContainer // line with pfp, username and time
+                    {
+                        Direction = FillDirection.Horizontal,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Spacing = new Vector2(8, 0),
+                        Children = new Drawable[]
+                        {
+                            new LoadWrapper<DrawableAvatar>
+                            {
+                                CornerRadius = 10,
+                                Origin = Anchor.CentreLeft,
+                                Anchor = Anchor.CentreLeft,
+                                Size = new Vector2(20, 20),
+                                Masking = true,
+                                LoadContent = () => new DrawableAvatar(action.User)
+                                {
+                                    RelativeSizeAxes = Axes.Both,
+                                    Anchor = Anchor.Centre,
+                                    Origin = Anchor.Centre
+                                },
+                            },
+                            new FluXisSpriteText
+                            {
+                                Origin = Anchor.CentreLeft,
+                                Anchor = Anchor.CentreLeft,
+                                WebFontSize = 12,
+                                Text = action.User.Username
+                            },
+                            new FluXisSpriteText
+                            {
+                                WebFontSize = 10,
+                                Origin = Anchor.CentreLeft,
+                                Anchor = Anchor.CentreLeft,
+                                Text = TimeUtils.GetFromSeconds(action.Timestamp).ToString("d MMM yyyy"),
+                                Colour = Theme.Text,
+                                Alpha = 0.8f,
+                            }
+                        }
+                    },
+                    new FluXisTextFlow
+                    {
+                        WebFontSize = 14,
+                        RelativeSizeAxes = Axes.X,
+                        AutoSizeAxes = Axes.Y,
+                        Text = action.Content,
+                    }
+                }
+            }
+        };
+    }
+}

--- a/fluXis/Overlay/MapSet/UI/Modding/ModdingActionCommentLeftSide.cs
+++ b/fluXis/Overlay/MapSet/UI/Modding/ModdingActionCommentLeftSide.cs
@@ -1,0 +1,60 @@
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Online.API.Models.Maps.Modding;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+
+namespace fluXis.Overlay.MapSet.UI.Modding;
+
+public partial class ModdingActionCommentLeftSide : GridContainer
+{
+    private readonly APIModdingActionType type;
+
+    public ModdingActionCommentLeftSide(APIModdingActionType type)
+    {
+        this.type = type;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        AutoSizeAxes = Axes.X;
+        RelativeSizeAxes = Axes.Y;
+
+        ColumnDimensions = new[]
+        {
+            new Dimension(GridSizeMode.AutoSize),
+        };
+
+        RowDimensions = new[]
+        {
+            new Dimension(GridSizeMode.AutoSize),
+            new Dimension(GridSizeMode.Absolute, 8),
+            new Dimension(GridSizeMode.Distributed)
+        };
+
+        Content = new[]
+        {
+            new Drawable[] { new ModdingActionTypeCircle(type), },
+            new Drawable[] { null }, // this represents the gap between the circle and the line
+            new Drawable[]
+            {
+                new Container
+                {
+                    Anchor = Anchor.TopCentre,
+                    Origin = Anchor.TopCentre,
+                    Width = 4,
+                    RelativeSizeAxes = Axes.Y,
+                    CornerRadius = 2,
+                    Masking = true,
+                    Child = new Box
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Colour = Theme.Background3
+                    }
+                }
+            }
+        };
+    }
+}

--- a/fluXis/Overlay/MapSet/UI/Modding/ModdingActionSimple.cs
+++ b/fluXis/Overlay/MapSet/UI/Modding/ModdingActionSimple.cs
@@ -1,0 +1,85 @@
+using fluXis.Graphics.Containers;
+using fluXis.Graphics.Sprites.Text;
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Online.API.Models.Maps.Modding;
+using fluXis.Online.Drawables.Images;
+using fluXis.Utils;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osuTK;
+
+namespace fluXis.Overlay.MapSet.UI.Modding;
+
+public partial class ModdingActionSimple : Container
+{
+    private readonly APIModdingAction action;
+
+    public ModdingActionSimple(APIModdingAction action)
+    {
+        this.action = action;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        string actionText =
+            action.Type == APIModdingActionType.Submitted ? " submitted the mapset to the queue " :
+            action.Type == APIModdingActionType.Update ? " updated the mapset " :
+            $" {action.Type.ToString()} "; // fallback for unhandled types
+
+        AutoSizeAxes = Axes.Y;
+        RelativeSizeAxes = Axes.X;
+
+        InternalChild = new FillFlowContainer
+        {
+            Direction = FillDirection.Horizontal,
+            AutoSizeAxes = Axes.Y,
+            RelativeSizeAxes = Axes.X,
+            Children = new Drawable[]
+            {
+                new ModdingActionTypeCircle(action.Type),
+                new LoadWrapper<DrawableAvatar>
+                {
+                    CornerRadius = 12,
+                    Margin = new MarginPadding { Left = 8, Right = 8 },
+                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    Size = new Vector2(24, 24),
+                    Masking = true,
+                    LoadContent = () => new DrawableAvatar(action.User)
+                    {
+                        RelativeSizeAxes = Axes.Both,
+                        Anchor = Anchor.Centre,
+                        Origin = Anchor.Centre
+                    },
+                },
+                new FluXisSpriteText
+                {
+                    WebFontSize = 14,
+                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    Text = action.User.PreferredName,
+                },
+                new FluXisSpriteText
+                {
+                    WebFontSize = 14,
+                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    Alpha = 0.8f,
+                    Text = actionText,
+                },
+                new FluXisSpriteText
+                {
+                    WebFontSize = 12,
+                    Origin = Anchor.CentreLeft,
+                    Anchor = Anchor.CentreLeft,
+                    Margin = new MarginPadding { Left = 4 },
+                    Colour = Theme.Text,
+                    Alpha = 0.6f,
+                    Text = TimeUtils.GetFromSeconds(action.Timestamp).ToString("d MMM yyyy"),
+                }
+            }
+        };
+    }
+}

--- a/fluXis/Overlay/MapSet/UI/Modding/ModdingActionTypeCircle.cs
+++ b/fluXis/Overlay/MapSet/UI/Modding/ModdingActionTypeCircle.cs
@@ -1,0 +1,58 @@
+using System.Collections.Generic;
+using fluXis.Graphics.Sprites.Icons;
+using fluXis.Graphics.UserInterface.Color;
+using fluXis.Online.API.Models.Maps.Modding;
+using osu.Framework.Allocation;
+using osu.Framework.Graphics;
+using osu.Framework.Graphics.Containers;
+using osu.Framework.Graphics.Shapes;
+using osu.Framework.Graphics.Sprites;
+using osuTK;
+
+namespace fluXis.Overlay.MapSet.UI.Modding;
+
+public partial class ModdingActionTypeCircle : Container
+{
+    private static readonly Dictionary<APIModdingActionType, (IconUsage, Colour4)> icon_map = new()
+    {
+        { APIModdingActionType.Note, (FontAwesome6.Solid.NoteSticky, Theme.Cyan) },
+        { APIModdingActionType.Approve, (FontAwesome6.Solid.Check, Theme.Green) },
+        { APIModdingActionType.Deny, (FontAwesome6.Solid.XMark, Theme.Red) },
+        { APIModdingActionType.Update, (FontAwesome6.Solid.ArrowsRotate, Theme.Yellow) },
+        { APIModdingActionType.Submitted, (FontAwesome6.Solid.AngleDoubleRight, Theme.Pink) }
+    };
+
+    private readonly APIModdingActionType type;
+
+    public ModdingActionTypeCircle(APIModdingActionType type)
+    {
+        this.type = type;
+    }
+
+    [BackgroundDependencyLoader]
+    private void load()
+    {
+        (IconUsage icon, Colour4 colour) = icon_map.ContainsKey(type)
+            ? icon_map[type]
+            : (FontAwesome6.Solid.Gear, Theme.Red); // fallback for unhandled types
+
+        Size = new Vector2(32, 32);
+        Children = new Drawable[]
+        {
+            new Circle
+            {
+                RelativeSizeAxes = Axes.Both,
+                Colour = Theme.Background2,
+            },
+            new FluXisSpriteIcon
+            {
+                Icon = icon,
+                Colour = colour,
+                RelativeSizeAxes = Axes.Both,
+                Origin = Anchor.Centre,
+                Anchor = Anchor.Centre,
+                Size = new Vector2(0.4f, 0.4f)
+            }
+        };
+    }
+}


### PR DESCRIPTION
implements the "modding" tab from the website into the game

<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/32d06d7f-e20b-4b2c-93fa-cf1830388892" />

<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/9600f1a6-86d9-4b97-957f-2fd5d00569f5" />

i couldn't figure out how properly make the left part of notes (the circle and the line) using only FillFlowContainers, so i used GridContainers, hopefully this is ok

closes #232