### PR TITLE
[BUGFIX] Fix Unstable Map Sort

### DIFF
--- a/fluXis/Utils/MapUtils.cs
+++ b/fluXis/Utils/MapUtils.cs
@@ -33,6 +33,9 @@ public static class MapUtils
             _ => 0
         };
 
+        if (result == 0)
+            result = first.GetHashCode().CompareTo(second.GetHashCode());
+
         if (inverse)
             result = -result;
 
@@ -53,6 +56,9 @@ public static class MapUtils
             SortingMode.Difficulty => compareDifficulty(first, second),
             _ => 0
         };
+
+        if (result == 0)
+            result = first.GetHashCode().CompareTo(second.GetHashCode());
 
         if (inverse)
             result = -result;


### PR DESCRIPTION
This happens way too often where somewhere in the comparation two items are returned equal to each other and we don't handle it and causes an exception.