### PR TITLE
Hide New Blends Modes Behind Experiments

### DIFF
--- a/fluXis/Configuration/Experiments/ExperimentConfigManager.cs
+++ b/fluXis/Configuration/Experiments/ExperimentConfigManager.cs
@@ -16,11 +16,13 @@ public class ExperimentConfigManager : IniConfigManager<ExperimentConfig>
     {
         SetDefault(ExperimentConfig.ModView, false);
         SetDefault(ExperimentConfig.LrcFeatures, false);
+        SetDefault(ExperimentConfig.NewSbBlendModes, false);
     }
 }
 
 public enum ExperimentConfig
 {
     ModView,
-    LrcFeatures
+    LrcFeatures,
+    NewSbBlendModes
 }

--- a/fluXis/Overlay/Settings/Sections/ExperimentsSection.cs
+++ b/fluXis/Overlay/Settings/Sections/ExperimentsSection.cs
@@ -27,6 +27,12 @@ public partial class ExperimentsSection : SettingsSection
             {
                 Label = ".lrc features",
                 Bindable = experiments.GetBindable<bool>(ExperimentConfig.LrcFeatures)
+            },
+            new SettingsToggle
+            {
+                Label = "Add new Blend Modes for storyboard elements",
+                Description = "Adds the option to use the new blend modes such as multiply and difference. Keep in mind, however, that they do not partially work with transparency.",
+                Bindable = experiments.GetBindable<bool>(ExperimentConfig.NewSbBlendModes)
             }
         });
     }

--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
 using fluXis.Configuration;
+using fluXis.Configuration.Experiments;
 using fluXis.Graphics.Containers;
 using fluXis.Graphics.Sprites.Icons;
 using fluXis.Graphics.Sprites.Text;
@@ -62,12 +63,23 @@ public partial class StoryboardElementSettings : CompositeDrawable
         Anchor.BottomRight
     };
 
+    private DefaultBlendingParameters[] nonExperimentalBlends { get; } =
+    {
+        DefaultBlendingParameters.None,
+        DefaultBlendingParameters.Mix,
+        DefaultBlendingParameters.Add,
+    };
+
+    private bool useExperimentalBlends;
+
     private FillFlowContainer flow;
 
     [BackgroundDependencyLoader]
-    private void load()
+    private void load(ExperimentConfigManager experiments)
     {
         RelativeSizeAxes = Axes.Both;
+
+        useExperimentalBlends = experiments.Get<bool>(ExperimentConfig.NewSbBlendModes);
 
         InternalChildren = new Drawable[]
         {
@@ -240,7 +252,7 @@ public partial class StoryboardElementSettings : CompositeDrawable
                     {
                         Text = "Blend Mode",
                         CurrentValue = item.BlendingMode,
-                        Items = Enum.GetValues<DefaultBlendingParameters>().ToList(),
+                        Items = useExperimentalBlends ? Enum.GetValues<DefaultBlendingParameters>().ToList() : nonExperimentalBlends.ToList(),
                         Enabled = blendingEnabled,
                         HideWhenDisabled = true,
                         OnValueChanged = mode =>


### PR DESCRIPTION
New blend modes are not stable so it would makes more sense to put it behind experiments. This is so that it's clear to anyone that any visually breaking and altering changes are communicated clearly until it is fixed.