### PR TITLE
Add 'Render Bounds Only' Parameter to Storyboard Text Elements

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
+++ b/fluXis/Screens/Edit/Tabs/Storyboarding/Settings/StoryboardElementSettings.cs
@@ -349,6 +349,16 @@ public partial class StoryboardElementSettings : CompositeDrawable
                                     map.Update(item);
                                 }
                             },
+                            new EditorVariableToggle
+                            {
+                                Text = "Render Bounds Only",
+                                CurrentValue = item.GetParameter("renderBoundsOnly", false),
+                                OnValueChanged = enabled =>
+                                {
+                                    item.Parameters["renderBoundsOnly"] = enabled;
+                                    map.Update(item);
+                                }
+                            }
                         });
                         break;
 

--- a/fluXis/Scripting/Models/Storyboarding/Elements/LuaStoryboardText.cs
+++ b/fluXis/Scripting/Models/Storyboarding/Elements/LuaStoryboardText.cs
@@ -15,11 +15,15 @@ public class LuaStoryboardText : LuaStoryboardElement
     [LuaMember(Name = "text")]
     public string Text { get; set; } = "text";
 
+    [LuaMember(Name = "renderBoundsOnly")]
+    public bool RenderBoundsOnly { get; set; }
+
     public override StoryboardElement Build()
     {
         var el = base.Build();
         el.Parameters["size"] = FontSize;
         el.Parameters["text"] = Text;
+        el.Parameters["renderBoundsOnly"] = RenderBoundsOnly;
         return el;
     }
 }

--- a/fluXis/Storyboards/Drawables/Elements/DrawableStoryboardText.cs
+++ b/fluXis/Storyboards/Drawables/Elements/DrawableStoryboardText.cs
@@ -21,11 +21,13 @@ public partial class DrawableStoryboardText : DrawableStoryboardElement
 
         var text = Element.GetParameter("text", string.Empty);
         var size = Element.GetParameter("size", 20f);
+        var renderBoundsOnly = Element.GetParameter("renderBoundsOnly", false);
 
         InternalChild = new FluXisSpriteText
         {
             Text = text,
-            FontSize = size
+            FontSize = size,
+            RenderBoundsOnly = renderBoundsOnly
         };
     }
 }

--- a/scripting/library/storyboard.lua
+++ b/scripting/library/storyboard.lua
@@ -108,6 +108,7 @@ local __StoryboardSprite = {}
 ---@class StoryboardText: StoryboardElement
 ---@field size number
 ---@field text string
+---@field renderBoundsOnly boolean
 local __StoryboardText = {}
 
 ---@alias AnimationType string


### PR DESCRIPTION
Requires:
- https://github.com/InventiveRhythm/osu-framework/pull/5