### PR TITLE
Fix Inconsistent Previews Between Gameplay and Design

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Design/DesignContainer.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/DesignContainer.cs
@@ -6,9 +6,11 @@ using fluXis.Graphics.Background;
 using fluXis.Graphics.Containers;
 using fluXis.Graphics.Shaders;
 using fluXis.Graphics.Sprites;
+using fluXis.Map;
 using fluXis.Map.Structures.Bases;
 using fluXis.Map.Structures.Events;
 using fluXis.Map.Structures.Events.Camera;
+using fluXis.Map.Structures.Events.Groups;
 using fluXis.Mods;
 using fluXis.Replays;
 using fluXis.Screens.Edit.Tabs.Design.Effects;
@@ -47,7 +49,8 @@ public partial class DesignContainer : EditorTabContainer
         typeof(PulseEvent),
         typeof(ShaderEvent),
         typeof(NoteEvent),
-        typeof(StoryboardElement)
+        typeof(StoryboardElement),
+        typeof(LoopEvent)
     };
 
     private DrawSizePreservingFillContainer drawSizePreserve;
@@ -74,11 +77,26 @@ public partial class DesignContainer : EditorTabContainer
 
     private BackgroundVideo backgroundVideo;
 
+    private MapEvents cachedEvents;
+
     [BackgroundDependencyLoader]
     private void load(FluXisConfig config)
     {
         userScrollSpeed = config.GetBindable<float>(FluXisSetting.ScrollSpeed);
     }
+
+    private MapEvents getCompiledEvents()
+    {
+        if (cachedEvents != null)
+            return cachedEvents;
+
+        var effects = Map.MapEvents.JsonCopy();
+        effects.Compile();
+        effects.Sort();
+        return cachedEvents = effects;
+    }
+
+    private void invalidateCompiled() => cachedEvents = null;
 
     protected override IEnumerable<Drawable> CreateContent()
     {
@@ -90,11 +108,19 @@ public partial class DesignContainer : EditorTabContainer
             Origin = Anchor.Centre,
         };
 
-        camera = new CameraContainer(Map.MapEvents.Where(x => x is ICameraEvent).Cast<ICameraEvent>().ToList());
+        var compiled = getCompiledEvents();
+
+        camera = new CameraContainer(compiled.Where(x => x is ICameraEvent).Cast<ICameraEvent>().ToList())
+        {
+            Clock = EditorClock
+        };
 
         return
         [
-            handler = new DesignShaderHandler(),
+            handler = new DesignShaderHandler
+            {
+                CompiledShaders = compiled.ShaderEvents
+            },
             rulesetIdleTracker = new IdleTracker(400, rebuildRuleset, () =>
             {
                 loadingIcon.Show();
@@ -121,7 +147,7 @@ public partial class DesignContainer : EditorTabContainer
                     backFlash = new EditorFlashLayer { Clock = EditorClock },
                     rulesetWrapper = new Container { RelativeSizeAxes = Axes.Both },
                 }),
-                pulseEffect = new PulseEffect(Map.MapEvents.PulseEvents) { Clock = EditorClock },
+                pulseEffect = new PulseEffect(compiled.PulseEvents) { Clock = EditorClock },
                 frontFlash = new EditorFlashLayer { Clock = EditorClock },
                 loadingIcon = new LoadingIcon
                 {
@@ -143,6 +169,8 @@ public partial class DesignContainer : EditorTabContainer
         Scheduler.AddOnce(rulesetIdleTracker.Reset);
         Map.AnyChange += t =>
         {
+            invalidateCompiled();
+
             if (t is not null)
             {
                 if (ignoredForRebuild.Contains(t.GetType()))
@@ -160,26 +188,23 @@ public partial class DesignContainer : EditorTabContainer
             Scheduler.AddOnce(rulesetIdleTracker.Reset);
         };
 
-        Map.RegisterAddListener<ShaderEvent>(_ => checkForRebuild());
-        Map.RegisterUpdateListener<ShaderEvent>(_ => checkForRebuild());
-        Map.RegisterRemoveListener<ShaderEvent>(_ => checkForRebuild());
+        registerListeners<LoopEvent>(rebuildAllCompiled);
+        registerListeners<ShaderEvent>(checkForShaderRebuild);
+        registerListeners<PulseEvent>(rebuildPulseEffect);
 
-        Map.RegisterAddListener<PulseEvent>(_ => pulseEffect.Rebuild());
-        Map.RegisterUpdateListener<PulseEvent>(_ => pulseEffect.Rebuild());
-        Map.RegisterRemoveListener<PulseEvent>(_ => pulseEffect.Rebuild());
-
-        registerCameraUpdate<CameraMoveEvent>();
-        registerCameraUpdate<CameraScaleEvent>();
-        registerCameraUpdate<CameraRotateEvent>();
+        registerListeners<CameraMoveEvent>(rebuildCamera);
+        registerListeners<CameraScaleEvent>(rebuildCamera);
+        registerListeners<CameraRotateEvent>(rebuildCamera);
 
         Editor.BindableBackgroundDim.BindValueChanged(e => backgroundDim.FadeTo(e.NewValue, 300));
         Editor.BindableBackgroundBlur.BindValueChanged(e => backgroundStack.Add(new BlurableBackground(Map.RealmMap, e.NewValue)), true);
+        return;
 
-        void registerCameraUpdate<T>() where T : class, ICameraEvent
+        void registerListeners<T>(Action action) where T : class, ITimedObject
         {
-            Map.RegisterAddListener<T>(_ => rebuildCamera());
-            Map.RegisterUpdateListener<T>(_ => rebuildCamera());
-            Map.RegisterRemoveListener<T>(_ => rebuildCamera());
+            Map.RegisterAddListener<T>(_ => action());
+            Map.RegisterUpdateListener<T>(_ => action());
+            Map.RegisterRemoveListener<T>(_ => action());
         }
     }
 
@@ -192,9 +217,7 @@ public partial class DesignContainer : EditorTabContainer
 
     private RulesetContainer createRuleset()
     {
-        var effects = Map.MapEvents.JsonCopy();
-        effects.Compile();
-        effects.Sort();
+        var effects = getCompiledEvents();
 
         backFlash.Rebuild(effects.FlashEvents.Where(x => x.InBackground).ToList());
         frontFlash.Rebuild(effects.FlashEvents.Where(x => !x.InBackground).ToList());
@@ -208,9 +231,10 @@ public partial class DesignContainer : EditorTabContainer
 
     private ShaderStackContainer createShaderStack()
     {
-        shaders = new ShaderStackContainer();
+        shaders = new ShaderStackContainer { Clock = EditorClock };
 
-        var shaderTypes = Map.MapEvents.ShaderEvents.Select(x => x.Type).Distinct();
+        var compiled = getCompiledEvents();
+        var shaderTypes = compiled.ShaderEvents.Select(x => x.Type).Distinct();
 
         foreach (var type in shaderTypes)
         {
@@ -224,13 +248,18 @@ public partial class DesignContainer : EditorTabContainer
         return shaders;
     }
 
-    private void checkForRebuild()
+    private void checkForShaderRebuild()
     {
         var current = shaders.ShaderTypes;
-        var shaderTypes = Map.MapEvents.ShaderEvents.Select(x => x.Type).Distinct();
+        var compiled = getCompiledEvents();
+        var shaderTypes = compiled.ShaderEvents.Select(x => x.Type).Distinct();
+
+        handler.CompiledShaders = compiled.ShaderEvents;
 
         if (!current.SequenceEqual(shaderTypes))
+        {
             rebuildShaderStack();
+        }
     }
 
     private void rebuildShaderStack()
@@ -242,8 +271,23 @@ public partial class DesignContainer : EditorTabContainer
 
     private void rebuildCamera()
     {
-        var events = Map.MapEvents.Where(x => x is ICameraEvent).Cast<ICameraEvent>().ToList();
+        var compiled = getCompiledEvents();
+        var events = compiled.Where(x => x is ICameraEvent).Cast<ICameraEvent>().ToList();
         camera.Refresh(events);
+    }
+
+    private void rebuildPulseEffect()
+    {
+        pulseEffect.Pulses = getCompiledEvents().PulseEvents;
+        pulseEffect.Rebuild();
+    }
+
+    private void rebuildAllCompiled()
+    {
+        checkForShaderRebuild();
+        rebuildCamera();
+        rebuildPulseEffect();
+        rulesetIdleTracker.Reset();
     }
 
     private void rebuildRuleset()

--- a/fluXis/Screens/Edit/Tabs/Design/DesignShaderHandler.cs
+++ b/fluXis/Screens/Edit/Tabs/Design/DesignShaderHandler.cs
@@ -11,12 +11,11 @@ namespace fluXis.Screens.Edit.Tabs.Design;
 public partial class DesignShaderHandler : CompositeComponent
 {
     [Resolved]
-    private EditorMap map { get; set; }
-
-    [Resolved]
     private EditorClock clock { get; set; }
 
     public ShaderStackContainer ShaderStack { get; set; }
+
+    public IEnumerable<ShaderEvent> CompiledShaders { get; set; } = Enumerable.Empty<ShaderEvent>();
 
     protected override void Update()
     {
@@ -25,7 +24,7 @@ public partial class DesignShaderHandler : CompositeComponent
         if (ShaderStack is null)
             return;
 
-        var groups = map.MapEvents.ShaderEvents.GroupBy(x => x.Type);
+        var groups = CompiledShaders.GroupBy(x => x.Type);
 
         foreach (var group in groups)
             handleGroup(group.Key, group);
@@ -48,12 +47,11 @@ public partial class DesignShaderHandler : CompositeComponent
             return;
         }
 
-        var progress = (clock.CurrentTime - current.Time) / current.Duration;
         var endStrength = current.EndParameters.Strength;
         var endStrength2 = current.EndParameters.Strength2;
         var endStrength3 = current.EndParameters.Strength3;
 
-        if (progress >= 1)
+        if (current.Duration <= 0 || clock.CurrentTime >= current.Time + current.Duration)
         {
             container.Strength = endStrength;
             container.Strength2 = endStrength2;
@@ -66,7 +64,7 @@ public partial class DesignShaderHandler : CompositeComponent
         var startStrength2 = current.UseStartValue ? current.StartParameters.Strength2 : previous?.EndParameters.Strength2 ?? 0;
         var startStrength3 = current.UseStartValue ? current.StartParameters.Strength3 : previous?.EndParameters.Strength3 ?? 0;
 
-        if (progress < 0)
+        if (clock.CurrentTime < current.Time)
         {
             container.Strength = startStrength;
             container.Strength2 = startStrength2;
@@ -74,8 +72,8 @@ public partial class DesignShaderHandler : CompositeComponent
             return;
         }
 
-        container.Strength = Interpolation.ValueAt(clock.CurrentTime, startStrength, endStrength, current.Time, current.Time + current.Duration);
-        container.Strength2 = Interpolation.ValueAt(clock.CurrentTime, startStrength2, endStrength2, current.Time, current.Time + current.Duration);
-        container.Strength3 = Interpolation.ValueAt(clock.CurrentTime, startStrength3, endStrength3, current.Time, current.Time + current.Duration);
+        container.Strength = Interpolation.ValueAt(clock.CurrentTime, startStrength, endStrength, current.Time, current.Time + current.Duration, current.Easing);
+        container.Strength2 = Interpolation.ValueAt(clock.CurrentTime, startStrength2, endStrength2, current.Time, current.Time + current.Duration, current.Easing);
+        container.Strength3 = Interpolation.ValueAt(clock.CurrentTime, startStrength3, endStrength3, current.Time, current.Time + current.Duration, current.Easing);
     }
 }

--- a/fluXis/Screens/Gameplay/Overlay/Effect/PulseEffect.cs
+++ b/fluXis/Screens/Gameplay/Overlay/Effect/PulseEffect.cs
@@ -4,6 +4,7 @@ using osu.Framework.Allocation;
 using osu.Framework.Graphics;
 using osu.Framework.Graphics.Containers;
 using osu.Framework.Graphics.Shapes;
+using osuTK;
 
 namespace fluXis.Screens.Gameplay.Overlay.Effect;
 
@@ -11,11 +12,11 @@ public partial class PulseEffect : Container
 {
     public override bool RemoveCompletedTransforms => false;
 
-    private List<PulseEvent> pulses { get; }
+    public List<PulseEvent> Pulses { get; set; }
 
     public PulseEffect(List<PulseEvent> pulses)
     {
-        this.pulses = pulses;
+        Pulses = pulses;
 
         RelativeSizeAxes = Axes.Both;
         BorderColour = Colour4.White;
@@ -38,6 +39,13 @@ public partial class PulseEffect : Container
     public void Rebuild()
     {
         ClearTransforms();
-        pulses.ForEach(p => p.Apply(this));
+
+        // Explicitly reset state, if we don't do this, seeking backwards PulseEffect gets stuck with
+        // whatever Transforms it had
+        Alpha = 1;
+        Scale = Vector2.One;
+        BorderThickness = 0;
+
+        Pulses.ForEach(p => p.Apply(this));
     }
 }

--- a/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
+++ b/fluXis/Screens/Gameplay/Ruleset/Playfields/Playfield.cs
@@ -69,6 +69,8 @@ public partial class Playfield : Container
     private Drawable topCover;
     private Drawable bottomCover;
 
+    private ShakeContainer shakeContainer;
+
     private Bindable<float> topCoverHeight;
     private Bindable<float> bottomCoverHeight;
     private Bindable<ScrollDirection> scrollDirection;
@@ -122,6 +124,7 @@ public partial class Playfield : Container
 
         InternalChildren = new[]
         {
+            shakeContainer = new ShakeContainer(),
             ColorManager,
             new LaneSwitchAlert(),
             Stage = new Stage(),
@@ -145,17 +148,46 @@ public partial class Playfield : Container
                     bottomCover = skin.GetLaneCover(true)
                 }
             },
-            new KeyOverlay(),
-            new EventHandler<ShakeEvent>(MapEvents.ShakeEvents, shake => ruleset.ShakeTarget.Shake(Math.Max(shake.Duration, 0), shake.Magnitude))
+            new KeyOverlay()
         };
 
         registerReloadableEvent(MapEvents.ColorFadeEvents);
         registerReloadableEvent(MapEvents.LayerFadeEvents);
         registerReloadableEvent(MapEvents.PlayfieldMoveEvents);
-        registerReloadableEvent(MapEvents.PlayfieldMoveEvents);
         registerReloadableEvent(MapEvents.PlayfieldScaleEvents);
         registerReloadableEvent(MapEvents.PlayfieldRotateEvents);
         MapEvents.TimeOffsetEvents.ForEach(e => e.Apply(HitManager));
+
+        // only register on the primary playfield
+        if (Index == 0 && !IsSubPlayfield)
+        {
+            registerReloadableShake(MapEvents.ShakeEvents);
+        }
+    }
+
+    // Shake is not an IApplicableToPlayfield
+    private void registerReloadableShake(List<ShakeEvent> shakes)
+    {
+        applyShakes(shakes);
+
+        ruleset.RegisterReload<ShakeEvent>(objs =>
+        {
+            shakeContainer.ClearTransforms(false, nameof(Position));
+            applyShakes(objs);
+        });
+    }
+
+    private void applyShakes(List<ShakeEvent> shakes)
+    {
+        shakeContainer.Position = Vector2.Zero;
+
+        foreach (var shake in shakes)
+        {
+            using (shakeContainer.BeginAbsoluteSequence(shake.Time))
+            {
+                shakeContainer.Shake(Math.Max(shake.Duration, 0), shake.Magnitude);
+            }
+        }
     }
 
     private void registerReloadableEvent<T>(List<T> initial) where T : IApplicableToPlayfield
@@ -184,6 +216,12 @@ public partial class Playfield : Container
 
         if (!IsSubPlayfield)
             hitsounding.PlayfieldPanning.Value = Math.Clamp(RelativePosition * 2 - 1, -1, 1) * hitsoundPanStrength.Value;
+
+        // We use ShakeContainer as a proxy for our shake for the ruleset container
+        if (Index == 0 && !IsSubPlayfield && ruleset.ShakeTarget != null)
+        {
+            ruleset.ShakeTarget.Position = shakeContainer.Position;
+        }
     }
 
     protected override IReadOnlyDependencyContainer CreateChildDependencies(IReadOnlyDependencyContainer parent)
@@ -213,4 +251,9 @@ public partial class Playfield : Container
     private float scaleForZ(float z) => -camera.Z / Math.Max(1f, z - camera.Z);
 
     #endregion
+
+    private partial class ShakeContainer : Container
+    {
+        public override bool RemoveCompletedTransforms => false;
+    }
 }


### PR DESCRIPTION
## Changes
- fixed missing easings for DesignShaderHandler
- fixed loops not in working design
- fixed shakes not working in design
- fixed pulse not working properly in design
- fixed possible zero division in DesignShaderHandler (progress calculation)

---

Shake wasn't seekable because RemoveCompletedTransforms is true by default for whatever the shake target was. We now use a proxy for the shake that doesn't remove its completed transforms.

Loops weren't working correctly for some events because some events need custom handlers/containers for them and previously we would pass map.MapEvents but now we actually pass the full compiled events generated from loops.

Pulse wasn't really Rebuilt properly because it needed to be reset.

Also Decoupled EditorMap from DesignShaderHandler because honestly that feels more appropriate (also EditorMap not needed as we just pass the shader events directly now).

Added `registerListeners` helper method just cuz it feels cleaner since we only use one delegate for all changes for a specific type.

We now cache event compilation so you should get compiled events from `DesignContainer.getCompiledEvents`, Though we invalidate it on every change so it might not look like much but it's a pretty meaningful change cuz from a single change, multiple rebuild methods (shaders, camera, pulse) each used to call `DesignContainer.getCompiledEvents` independently meaning one event change could trigger 3 or 4 full compiles instead of one. The cache just means all of them now share a single compiled result per change instead of redoing the same work repeatedly.