### PR TITLE
fix incorrect clamp on osu SVs

### DIFF
--- a/fluXis.Import.osu/Map/Components/OsuTimingPoint.cs
+++ b/fluXis.Import.osu/Map/Components/OsuTimingPoint.cs
@@ -16,7 +16,7 @@ public class OsuTimingPoint
     // some gimmick maps might have absurdly high bpm. fluxis doesn't like that, so let's cap it at a reasonable 10 millions bpm.
     public float BPM => Math.Clamp(60000 / BeatLength, 1, 10000000);
 
-    public double ScrollMultiplier => Math.Clamp(-100 / (double)BeatLength, 0.1f, 10);
+    public double ScrollMultiplier => Math.Clamp(-100 / (double)BeatLength, 0.01f, 10);
 
     public TimingPoint ToTimingPointInfo()
     {


### PR DESCRIPTION
reported in mapping channel by matero
https://discord.com/channels/994666749570076764/995707535665410129/1530341405174796308

somehow i didnt catch this when making the previous pr related to osu SVs