### PR TITLE
properly register SV type in ChartingPointsList

### DIFF
--- a/fluXis/Screens/Edit/Tabs/Charting/Points/ChartingPointsList.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Points/ChartingPointsList.cs
@@ -23,8 +23,7 @@ public partial class ChartingPointsList : PointsList
     protected override void RegisterEvents()
     {
         RegisterTypeEvents(Map.MapInfo.TimingPoints);
-        RegisterTypeEvents(Map.MapEvents.LaneSwitchEvents);
-        RegisterTypeEvents(Map.MapEvents.NoteEvents);
+        RegisterTypeEvents(Map.MapInfo.ScrollVelocities);
 
         foreach (var (type, list) in Map.MapEvents.GetListsForTypes())
         {


### PR DESCRIPTION
vro what have you done to sv

also, LaneSwitchEvents and NoteEvents are already returned by Map.MapEvents.GetListsForTypes(), which mean they are registered two times, that leads to 2 entries being added to the list when adding a lane switch or a note event

this pr just does the bare minimum to make sv somewhat editable again, a lot of other things related to scroll velocities are broken by the new editor changes (SVs are displayed in the editor playfield despite being annotated with [DoNotShowInEditorPlayfield], so like im not really sure what that annotation is even supposed to do, SVs that were present when loading the maps are selectable and draggable in the editor playfield, while newly added ones are not, they still visually appear though)