### PR TITLE
Fix Editor Event Objects Not Updating

### DIFF
--- a/fluXis/Screens/Edit/Actions/Generic/ObjectMoveAction.cs
+++ b/fluXis/Screens/Edit/Actions/Generic/ObjectMoveAction.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq;
 using fluXis.Map.Structures.Bases;
 using fluXis.Screens.Edit.Tabs;
+using osu.Framework.Utils;
 using osuTK;
 
 namespace fluXis.Screens.Edit.Actions.Generic;
@@ -21,10 +22,10 @@ public class ObjectMoveAction<T> : EditorAction
         newPos = [.. originalPos]; // copy, since it gets updated later
     }
 
-    public override void Run(EditorMap map) => Apply(newPos, false);
-    public override void Undo(EditorMap map) => Apply(originalPos, false);
+    public override void Run(EditorMap map) => Apply(map, newPos, false);
+    public override void Undo(EditorMap map) => Apply(map, originalPos, false);
 
-    public void Apply(Vector2d[] vecs, bool update)
+    public void Apply(EditorMap map, Vector2d[] vecs, bool update)
     {
         if (update)
             newPos = vecs;
@@ -34,8 +35,12 @@ public class ObjectMoveAction<T> : EditorAction
             var info = infos[i];
             var vec = vecs[i];
 
+            bool timeChanged = !Precision.AlmostEquals(info.Time, vec[0]);
+
             info.Time = vec[0];
             info.Lane = (int)vec[1];
+
+            if (timeChanged && update) map.Update(info);
         }
     }
 

--- a/fluXis/Screens/Edit/Actions/Generic/ObjectRecaledAction.cs
+++ b/fluXis/Screens/Edit/Actions/Generic/ObjectRecaledAction.cs
@@ -1,0 +1,51 @@
+using System.Linq;
+using fluXis.Map.Structures.Bases;
+using fluXis.Screens.Edit.Tabs;
+using osu.Framework.Utils;
+using osuTK;
+
+namespace fluXis.Screens.Edit.Actions.Generic;
+
+public class ObjectRescaledAction<T> : EditorAction
+    where T : ITimedObject, IHasDuration
+{
+    public override string Description => $"Rescale {infos.Length} {ChartingTab.FormatTypeName<T>(infos.Length > 1)}";
+
+    private T[] infos { get; }
+    private Vector2d[] originalState { get; }
+    private Vector2d[] newState;
+
+    public ObjectRescaledAction(T[] infos)
+    {
+        this.infos = infos;
+        originalState = CreateFrom([.. infos]);
+        newState = [.. originalState]; // copy, since it gets updated later
+    }
+
+    public override void Run(EditorMap map) => Apply(map, newState, false);
+    public override void Undo(EditorMap map) => Apply(map, originalState, false);
+
+    public void Apply(EditorMap map, Vector2d[] vecs, bool update)
+    {
+        if (update)
+            newState = vecs;
+
+        for (var i = 0; i < infos.Length; i++)
+        {
+            var info = infos[i];
+            var vec = vecs[i];
+
+            bool timeChanged = !Precision.AlmostEquals(info.Time, vec[0]);
+            bool durationChanged = !Precision.AlmostEquals(info.Duration, vec[1]);
+
+            info.Time = vec[0];
+            info.Duration = vec[1];
+
+            if ((timeChanged || durationChanged) && update)
+                map.Update(info);
+        }
+    }
+
+    public static Vector2d[] CreateFrom(T[] objs)
+        => objs.Select(x => new Vector2d(x.Time, x.Duration)).ToArray();
+}

--- a/fluXis/Screens/Edit/Tabs/Charting/Blueprints/ChartingBlueprintContainer.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Blueprints/ChartingBlueprintContainer.cs
@@ -240,7 +240,7 @@ public partial class ChartingBlueprintContainer : BlueprintContainer<ITimedObjec
 
         var objs = hitBlueprints.Select(b => b.Object).ToArray();
         var vecs = ObjectMoveAction<ITimedObject>.CreateFrom(objs);
-        moveAction?.Apply([.. vecs.Select(v => new Vector2d(v.X + timeDelta, v.Y + laneDelta))], true);
+        moveAction?.Apply(map, [.. vecs.Select(v => new Vector2d(v.X + timeDelta, v.Y + laneDelta))], true);
     }
 
     protected override void FinishedMoving()
@@ -306,7 +306,7 @@ public partial class ChartingBlueprintContainer : BlueprintContainer<ITimedObjec
             if (!changed)
                 return false;
 
-            action.Apply(ObjectMoveAction<HitObject>.CreateFrom([.. selected]), true);
+            action.Apply(map, ObjectMoveAction<HitObject>.CreateFrom([.. selected]), true);
             actions.Add(action);
             return true;
         }

--- a/fluXis/Screens/Edit/Tabs/Charting/Blueprints/Selection/ChartingSelectionBlueprint.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Blueprints/Selection/ChartingSelectionBlueprint.cs
@@ -2,6 +2,8 @@
 using fluXis.Audio;
 using fluXis.Map.Structures;
 using fluXis.Map.Structures.Bases;
+using fluXis.Screens.Edit.Actions;
+using fluXis.Screens.Edit.Actions.Generic;
 using fluXis.Screens.Edit.Blueprints.Selection;
 using fluXis.Screens.Edit.Tabs.Charting.Playfield;
 using osu.Framework.Allocation;
@@ -30,6 +32,9 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
 
     [Resolved]
     protected EditorSettings EditorSettings { get; private set; }
+
+    [Resolved]
+    private EditorActionStack actions { get; set; }
 
     public override RectangleF ScreenSpaceSelectionRect
     {
@@ -67,6 +72,7 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
     private readonly DraggableSelectionPiece end;
 
     private DebouncedSample sample;
+    private ObjectRescaledAction<IHasDuration> rescaleAction;
 
     public ChartingSelectionBlueprint(ITimedObject obj)
         : base(obj)
@@ -82,6 +88,7 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
             head = new DraggableSelectionPiece
             {
                 DragAction = dragStart,
+                DragEndAction = finishRescale,
                 Anchor = Anchor.BottomLeft,
                 Origin = Anchor.BottomLeft,
                 Alpha = 0
@@ -89,6 +96,7 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
             end = new DraggableSelectionPiece
             {
                 DragAction = dragEnd,
+                DragEndAction = finishRescale,
                 Origin = Anchor.TopLeft,
                 Alpha = 0
             },
@@ -150,6 +158,8 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
         if (Object is not IHasDuration d)
             return;
 
+        rescaleAction ??= new ObjectRescaledAction<IHasDuration>([d]);
+
         var newTime = PositionProvider.TimeAtScreenSpacePosition(vec);
         newTime = Snaps.SnapTime(newTime);
         var newLen = d.GetEndTime() - newTime;
@@ -160,8 +170,7 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
         if (Math.Abs(d.Time - newTime) > 0.1f)
             sample?.Play();
 
-        d.Time = newTime;
-        d.Duration = newLen;
+        rescaleAction.Apply(Map, [new Vector2d(newTime, newLen)], true);
     }
 
     private void dragEnd(Vector2 vec)
@@ -169,9 +178,11 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
         if (Object is not IHasDuration d)
             return;
 
+        rescaleAction ??= new ObjectRescaledAction<IHasDuration>([d]);
+
         var newTime = PositionProvider.TimeAtScreenSpacePosition(vec);
         newTime = Snaps.SnapTime(newTime);
-        var newLen = newTime - Object.Time;
+        var newLen = newTime - d.Time;
 
         if (newLen <= 10)
             return;
@@ -179,6 +190,17 @@ public partial class ChartingSelectionBlueprint : SelectionBlueprint<ITimedObjec
         if (Math.Abs(d.GetEndTime() - newTime) > 0.1f)
             sample?.Play();
 
-        d.Duration = newTime - d.Time;
+        rescaleAction.Apply(Map, [new Vector2d(d.Time, newLen)], true);
+    }
+
+    private void finishRescale()
+    {
+        if (rescaleAction is null)
+        {
+            return;
+        }
+
+        actions.Add(rescaleAction);
+        rescaleAction = null;
     }
 }

--- a/fluXis/Screens/Edit/Tabs/Charting/Blueprints/Selection/DraggableSelectionPiece.cs
+++ b/fluXis/Screens/Edit/Tabs/Charting/Blueprints/Selection/DraggableSelectionPiece.cs
@@ -14,6 +14,7 @@ public partial class DraggableSelectionPiece : Container, IHasCursorType
     CursorType IHasCursorType.Cursor => CursorType.SizeVertical;
 
     public Action<Vector2> DragAction { get; init; }
+    public Action DragEndAction { get; init; }
 
     private readonly BlueprintNotePiece piece;
 
@@ -41,6 +42,12 @@ public partial class DraggableSelectionPiece : Container, IHasCursorType
     }
 
     protected override bool OnDragStart(DragStartEvent e) => e.Button == MouseButton.Left;
+
+    protected override void OnDragEnd(DragEndEvent e)
+    {
+        DragEndAction?.Invoke();
+        base.OnDragEnd(e);
+    }
 
     protected override void OnDrag(DragEvent e)
     {

--- a/fluXis/Screens/Edit/Tabs/ChartingTab.cs
+++ b/fluXis/Screens/Edit/Tabs/ChartingTab.cs
@@ -56,11 +56,17 @@ public partial class ChartingTab : EditorTab
     public static string FormatTypeName<T>(bool multiple = false, bool title = false) where T : ITimedObject
     {
         var type = typeof(T);
-        var desc = type.Name.Replace("Event", "").Titleize();
-        desc = desc.Replace("Hit Object", "HitObject");
+        string desc;
 
-        if (type == typeof(ITimedObject))
+        if (type.IsInterface)
+        {
             desc = "Object";
+        }
+        else
+        {
+            desc = type.Name.Replace("Event", "").Titleize();
+            desc = desc.Replace("Hit Object", "HitObject");
+        }
 
         if (!title) desc = desc.ToLower();
 


### PR DESCRIPTION
Moving or scaling an event object doesn't reflect any changes. This aims to fix it.

## Changes:
- Added an action for rescaling objects
- Moving an object's time now updates the event (for it to register in the preview, same for rescale)
  * this also fixes hitobjects not updating preview not just events