### PR TITLE
Improve Menu Visualizers

### DIFF
--- a/fluXis/Audio/FFT/AudioAnalyzer.cs
+++ b/fluXis/Audio/FFT/AudioAnalyzer.cs
@@ -98,29 +98,7 @@ public partial class AudioAnalyzer : Component
     public long ChannelLength { get; private set; }
     private bool isReady;
 
-    private FFTCache getOrCreateCache(string hash)
-    {
-        if (caches.TryGetValue(hash, out var existing))
-        {
-            lru.Remove(hash);
-            lru.AddFirst(hash);
-            return existing;
-        }
-
-        if (caches.Count >= max_cached)
-        {
-            string lruKey = lru.Last!.Value;
-            lru.RemoveLast();
-            caches[lruKey].Dispose();
-            caches.Remove(lruKey);
-        }
-
-        var cache = tryLoadCacheFromDisk(hash) ?? new FFTCache { Hash = hash };
-        caches[hash] = cache;
-        lru.AddFirst(hash);
-
-        return cache;
-    }
+    #region Public Interface
 
     public virtual void SetAudio(RealmMap map)
     {
@@ -206,26 +184,6 @@ public partial class AudioAnalyzer : Component
         ComputeComplete = Task.Run(() => precomputeFullTrack(token), token);
     }
 
-    private void precomputeFullTrack(CancellationToken token = default)
-    {
-        if (!isReady || currentCache == null) return;
-
-        double lengthMs = Bass.ChannelBytes2Seconds(decodeStreamHandle, ChannelLength) * 1000.0;
-        uint totalTime = (uint)Math.Ceiling(lengthMs / RESOLUTION) * RESOLUTION + RESOLUTION;
-
-        currentCache.ContainsAndAllocate(0, totalTime, out var missing);
-
-        foreach (var range in missing)
-        {
-            token.ThrowIfCancellationRequested();
-            ComputeRange(range);
-        }
-
-        SaveCacheToDisk();
-
-        Logger.Log($"FFT Full track cached for {AudioFileName}, mapSetID: {ID}.");
-    }
-
     public virtual FFTFrame[] GetAmplitudes(
         int tStart,
         int tEnd,
@@ -256,25 +214,7 @@ public partial class AudioAnalyzer : Component
         )).ToArray();
     }
 
-    private static float[] resizeArray(float[] data, int newSize)
-    {
-        if (data.Length == newSize) return data;
-
-        var result = new float[newSize];
-        float ratio = (float)data.Length / newSize;
-
-        for (int i = 0; i < newSize; i++)
-        {
-            float position = i * ratio;
-            int index1 = (int)position;
-            int index2 = Math.Min(index1 + 1, data.Length - 1);
-            float fraction = position - index1;
-
-            result[i] = (float)Interpolation.Lerp(data[index1], data[index2], fraction);
-        }
-
-        return result;
-    }
+    #endregion
 
     protected virtual void ComputeRange([In, Out] FFTRange range)
     {
@@ -309,12 +249,101 @@ public partial class AudioAnalyzer : Component
             range.Data[offset + FFT_BINS + 0] = floatToByte(computeIntensity(channelInfo, bins, low_min, mid_min));
             range.Data[offset + FFT_BINS + 1] = floatToByte(computeIntensity(channelInfo, bins, mid_min, high_min));
             range.Data[offset + FFT_BINS + 2] = floatToByte(computeIntensity(channelInfo, bins, high_min, high_max));
-            range.Data[offset + FFT_BINS + 3] = floatToByte(computeTotalIntensity(bins));
+            range.Data[offset + FFT_BINS + 3] = floatToByte(ComputeTotalIntensity(bins));
         }
     }
 
-    private static byte floatToByte(float value) =>
-        (byte)(Math.Clamp(value, 0f, 1f) * 255f);
+    // In the (very far) future we'd like to actually be able to compute proper fft data in ranges
+    private void precomputeFullTrack(CancellationToken token = default)
+    {
+        if (!isReady || currentCache == null) return;
+
+        double lengthMs = Bass.ChannelBytes2Seconds(decodeStreamHandle, ChannelLength) * 1000.0;
+        uint totalTime = (uint)Math.Ceiling(lengthMs / RESOLUTION) * RESOLUTION + RESOLUTION;
+
+        currentCache.ContainsAndAllocate(0, totalTime, out var missing);
+
+        foreach (var range in missing)
+        {
+            token.ThrowIfCancellationRequested();
+            ComputeRange(range);
+        }
+
+        SaveCacheToDisk();
+
+        Logger.Log($"FFT Full track cached for {AudioFileName}, mapSetID: {ID}.");
+    }
+
+    #region Intensity
+
+    // These might need a lot of rework to their weights in the future but I guess these work with what we're using
+
+    public static float ComputeLowIntensity(float[] bins)
+    {
+        int bassBinCount = FFT_BINS / 8;
+
+        float sum = 0;
+        float maxPossibleSum = 0;
+
+        for (int i = 0; i < bassBinCount; i++)
+        {
+            float weight = 1.0f + ((float)i / bassBinCount) * 3.0f;
+            sum += bins[i] * weight;
+            maxPossibleSum += weight;
+        }
+
+        float normalized = sum / maxPossibleSum;
+        return MathF.Sqrt(normalized);
+    }
+
+    public static float ComputeMidIntensity(float[] bins)
+    {
+        int low = (int)(bins.Length * 0.25f);
+        int high = (int)(bins.Length * 0.60f);
+        int count = high - low;
+
+        float sum = 0;
+        float maxPossibleSum = 0;
+
+        for (int i = low; i < high; i++)
+        {
+            float weight = 1.0f;
+            sum += bins[i] * weight;
+            maxPossibleSum += weight;
+        }
+
+        return sum / maxPossibleSum;
+    }
+
+    public static float ComputeHighIntensity(float[] bins)
+    {
+        int low = (int)(bins.Length * 0.60f);
+
+        float sum = 0;
+        float maxPossibleSum = 0;
+
+        for (int i = low; i < bins.Length; i++)
+        {
+            float weight = 1.0f;
+            sum += bins[i] * weight;
+            maxPossibleSum += weight;
+        }
+
+        return sum / maxPossibleSum;
+    }
+
+    public static float ComputeTotalIntensity(float[] bins)
+    {
+        float sum = 0;
+
+        for (int i = 0; i < FFT_BINS; i++)
+        {
+            float weight = 1.0f + ((float)i / FFT_BINS) * 15.0f;
+            sum += bins[i] * weight;
+        }
+
+        return MathF.Sqrt(sum / FFT_BINS) * 1.5f;
+    }
 
     private static float computeIntensity(ChannelInfo info, float[] bins, float startFrequency, float endFrequency)
     {
@@ -340,17 +369,32 @@ public partial class AudioAnalyzer : Component
         return MathF.Sqrt(sum / (endBin - startBin)) * 1.5f;
     }
 
-    private static float computeTotalIntensity(float[] bins)
-    {
-        float sum = 0;
+    #endregion
 
-        for (int i = 0; i < FFT_BINS; i++)
+    #region Cache
+
+    private FFTCache getOrCreateCache(string hash)
+    {
+        if (caches.TryGetValue(hash, out var existing))
         {
-            float weight = 1.0f + ((float)i / FFT_BINS) * 15.0f;
-            sum += bins[i] * weight;
+            lru.Remove(hash);
+            lru.AddFirst(hash);
+            return existing;
         }
 
-        return MathF.Sqrt(sum / FFT_BINS) * 1.5f;
+        if (caches.Count >= max_cached)
+        {
+            string lruKey = lru.Last!.Value;
+            lru.RemoveLast();
+            caches[lruKey].Dispose();
+            caches.Remove(lruKey);
+        }
+
+        var cache = tryLoadCacheFromDisk(hash) ?? new FFTCache { Hash = hash };
+        caches[hash] = cache;
+        lru.AddFirst(hash);
+
+        return cache;
     }
 
     private FFTCache tryLoadCacheFromDisk(string hash)
@@ -410,8 +454,37 @@ public partial class AudioAnalyzer : Component
         }
     }
 
+    #endregion
+
+    #region Helpers
+
+    private static float[] resizeArray(float[] data, int newSize)
+    {
+        if (data.Length == newSize) return data;
+
+        var result = new float[newSize];
+        float ratio = (float)data.Length / newSize;
+
+        for (int i = 0; i < newSize; i++)
+        {
+            float position = i * ratio;
+            int index1 = (int)position;
+            int index2 = Math.Min(index1 + 1, data.Length - 1);
+            float fraction = position - index1;
+
+            result[i] = (float)Interpolation.Lerp(data[index1], data[index2], fraction);
+        }
+
+        return result;
+    }
+
+    private static byte floatToByte(float value) =>
+        (byte)(Math.Clamp(value, 0f, 1f) * 255f);
+
     protected static void LogBassError(string reason) =>
         Logger.Log($"BASS failure in {nameof(AudioAnalyzer)}: {reason} ({Bass.LastError})");
+
+    #endregion
 
     protected override void Dispose(bool isDisposing)
     {

--- a/fluXis/Graphics/Background/GlobalBackground.cs
+++ b/fluXis/Graphics/Background/GlobalBackground.cs
@@ -1,7 +1,7 @@
 using System;
-using System.Linq;
 using System.Threading;
 using fluXis.Audio;
+using fluXis.Audio.FFT;
 using fluXis.Configuration;
 using fluXis.Database.Maps;
 using fluXis.Graphics.Containers;
@@ -33,12 +33,12 @@ public partial class GlobalBackground : CompositeDrawable
     private string currentBackground;
     private float blur;
 
+    private float currentScale = 1f;
+
     private Bindable<bool> backgroundPulse;
 
     [CanBeNull]
     private CancellationTokenSource cancellationSource;
-
-    private float amplitude;
 
     public float Zoom { set => stack.ScaleTo(value, 1000, Easing.OutQuint); }
     public float ParallaxStrength { set => parallaxContainer.Strength = value; }
@@ -112,18 +112,20 @@ public partial class GlobalBackground : CompositeDrawable
 
         if (backgroundPulse.Value)
         {
-            var amplitudes = amplitudeProvider.Amplitudes
-                                              .Where((_, i) => i is > 0 and < 128)
-                                              .Select((amp, i) => (amp, index: i + 1))
-                                              .ToList();
+            float bass = AudioAnalyzer.ComputeLowIntensity(amplitudeProvider.Amplitudes);
+            const float noiseFloor = 0.02f;
+            float bassShaped = MathF.Max(0f, bass - noiseFloor) / (1f - noiseFloor);
+            float amplitude = MathF.Min(MathF.Pow(bassShaped, 4f), 4f);
 
-            float decay = 0.15f; // the lower the value the more biased we are to the bass
-            float weightedSum = amplitudes.Sum(x => x.amp * MathF.Pow(decay, x.index));
-            float totalWeight = amplitudes.Sum(x => MathF.Pow(decay, x.index));
-            float newSample = totalWeight > 0 ? weightedSum / totalWeight : 0f;
+            if (float.IsNaN(amplitude) || !float.IsFinite(amplitude))
+                amplitude = 1;
 
-            amplitude = Math.Min(amplitude * 0.7f + newSample * 0.3f, 1f);
-            Scale = new Vector2(1 + amplitude * .02f);
+            float target = 1 + amplitude * .055f; // increase this number a bit to zoom into the universe
+
+            float delta = (float)Time.Elapsed / 1000f;
+
+            currentScale = target > currentScale ? target : MathF.Max(target, currentScale - 2.5f * delta);
+            Scale = new Vector2(currentScale);
         }
 
         base.Update();

--- a/fluXis/Graphics/Styling.cs
+++ b/fluXis/Graphics/Styling.cs
@@ -56,9 +56,12 @@ public static class Styling
         SpatialWindowSize = 1,
         Gamma = 1.1f,
         ReleaseHigh = 0.2f,
-        BassFloor = 0.5f,
+        BassFloor = 0.35f,
+        MidFloor = 0.04f,
+        HighFloor = 0.015f,
         BassMultiplier = 1f,
-        HighMultiplier = 1.15f,
+        MidMultiplier = 1.3f,
+        HighMultiplier = 1.5f,
         MaxAdaptationRate = 0.2f
     };
 

--- a/fluXis/Screens/Menu/UI/Visualizer/MenuVisualizer.cs
+++ b/fluXis/Screens/Menu/UI/Visualizer/MenuVisualizer.cs
@@ -1,6 +1,6 @@
 using System;
-using System.Linq;
 using fluXis.Audio;
+using fluXis.Audio.FFT;
 using fluXis.Configuration;
 using osu.Framework.Allocation;
 using osu.Framework.Bindables;
@@ -21,11 +21,11 @@ public partial class MenuVisualizer : Container
     private const int max_extra_speed = 2;
     private const int max_extra_scale = 0;
 
-    private float amplitude = 0f;
-
     private bool loaded;
     private Bindable<bool> visualizerEnabled;
     private Bindable<bool> swayEnabled;
+
+    private float smoothedAmplitude;
 
     public MenuVisualizer()
     {
@@ -73,17 +73,31 @@ public partial class MenuVisualizer : Container
 
     protected override void Update()
     {
-        var amplitudes = amplitudeProvider.Amplitudes
-                                          .Where((_, i) => i is > 0 and < 128)
-                                          .Select((amp, i) => (amp, index: i + 1))
-                                          .ToList();
+        float bass = AudioAnalyzer.ComputeLowIntensity(amplitudeProvider.Amplitudes);
+        float mid = AudioAnalyzer.ComputeMidIntensity(amplitudeProvider.Amplitudes);
+        float high = AudioAnalyzer.ComputeHighIntensity(amplitudeProvider.Amplitudes);
 
-        float decay = 0.85f; // the lower the value the more biased we are to the bass
-        float weightedSum = amplitudes.Sum(x => x.amp * x.amp * MathF.Pow(decay, x.index));
-        float totalWeight = amplitudes.Sum(x => x.amp * MathF.Pow(decay, x.index));
-        float newSample = totalWeight > 0 ? weightedSum / totalWeight : 0f;
+        const float noiseFloor = 0.05f;
+        float bassSmooth = MathF.Max(0f, bass - noiseFloor) / (1f - noiseFloor);
+        float midSmooth = MathF.Max(0f, mid - noiseFloor) / (1f - noiseFloor);
+        float highSmooth = MathF.Max(0f, high - noiseFloor) / (1f - noiseFloor);
 
-        amplitude = Math.Min(amplitude * 0.75f + newSample * 0.3f, 0.65f);
+        float bassContrib = MathF.Pow(bassSmooth, 3f);
+        float midContrib = midSmooth * 1.25f;
+        float highContrib = highSmooth * 10f;
+
+        float targetAmplitude = MathF.Min(bassContrib + midContrib + highContrib, 1f) * 0.975f + 0.05f;
+
+        if (float.IsNaN(targetAmplitude) || !float.IsFinite(targetAmplitude))
+            targetAmplitude = 1;
+
+        const double attackHalfTime = 15; // rise
+        const double decayHalfTime = 180; // fall off
+
+        double halfTime = targetAmplitude > smoothedAmplitude ? attackHalfTime : decayHalfTime;
+        smoothedAmplitude = (float)Interpolation.DampContinuously(smoothedAmplitude, targetAmplitude, halfTime, Time.Elapsed);
+
+        float amplitude = smoothedAmplitude;
 
         foreach (var child in Children)
         {


### PR DESCRIPTION
I wasn't satisfied with the initial rework of the visualizers for the shapes and background pulse but, now it's feels more reactive. It might get tweaked more in the future but, this is way better than it was post-visualization rework.

## Changes:
- Organize `AudioAnalyzer` (cuz why not)
- Add Intensity calc methods for frequencies
- Improve Menu Visualizer
- Improve Background Pulse
- Tweak global fft params a bit (It affects the pulse and menu visualizer more than the bar visualizer for music player)